### PR TITLE
Personography merge feature

### DIFF
--- a/mep/accounts/models.py
+++ b/mep/accounts/models.py
@@ -6,6 +6,7 @@ from django.core.validators import ValidationError
 from django.db import models
 from django.template.defaultfilters import pluralize
 
+from mep.books.models import Item
 from mep.common.models import Named, Notable
 from mep.people.models import Person, Location
 
@@ -393,7 +394,7 @@ class Borrow(Event):
 class Purchase(Event, CurrencyMixin):
     '''Inherited table indicating purchase events'''
     price = models.DecimalField(max_digits=8, decimal_places=2)
-    item = models.ForeignKey('books.Item')
+    item = models.ForeignKey(Item)
 
 
 class Reimbursement(Event, CurrencyMixin):

--- a/mep/accounts/models.py
+++ b/mep/accounts/models.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from cached_property import cached_property
 from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import ValidationError
@@ -201,7 +202,7 @@ class Event(Notable):
         return '%s for account #%s' % (self.__class__.__name__,
                                       self.account.pk)
 
-    @property
+    @cached_property
     def event_type(self):
         try:
             return self.subscription.get_subtype_display()
@@ -210,6 +211,16 @@ class Event(Notable):
         try:
             self.reimbursement
             return 'Reimbursement'
+        except ObjectDoesNotExist:
+            pass
+        try:
+            self.borrow
+            return 'Borrow'
+        except ObjectDoesNotExist:
+            pass
+        try:
+            self.purchase
+            return 'Purchase'
         except ObjectDoesNotExist:
             pass
         return 'Generic'

--- a/mep/accounts/tests/test_accounts_models.py
+++ b/mep/accounts/tests/test_accounts_models.py
@@ -286,6 +286,16 @@ class TestEvent(TestCase):
         )
         assert reimbursement.event_ptr.event_type == 'Reimbursement'
 
+        # borrow
+        borrow = Borrow.objects.create(account=self.account)
+        assert borrow.event_ptr.event_type == 'Borrow'
+
+        # purchase
+        item = Item.objects.create()
+        borrow = Purchase.objects.create(account=self.account, item=item, price=5)
+        assert borrow.event_ptr.event_type == 'Purchase'
+
+
 class TestSubscription(TestCase):
 
     def setUp(self):

--- a/mep/common/models.py
+++ b/mep/common/models.py
@@ -12,8 +12,11 @@ class AliasIntegerField(models.IntegerField):
     '''
 
     def contribute_to_class(self, cls, name, virtual_only=False):
-        super(AliasIntegerField, self).contribute_to_class(cls, name, virtual_only=True)
+        # configure as a non-concrete field (no db column associated)
+        super(AliasIntegerField, self).contribute_to_class(cls, name, virtual_only=True,)
+        self.concrete = False
         setattr(cls, name, self)
+
 
     def __get__(self, instance, instance_type=None):
         if not instance:

--- a/mep/people/admin.py
+++ b/mep/people/admin.py
@@ -2,6 +2,8 @@ from dal import autocomplete
 from django import forms
 from django.conf import settings
 from django.contrib import admin
+from django.http import HttpResponseRedirect
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 from viapy.widgets import ViafWidget
 
@@ -154,8 +156,17 @@ class PersonAdmin(admin.ModelAdmin):
     # NOTE: using a locally customized version of django's prepopulate.js
     # to allow using the prepopulate behavior without slugifying the value
 
+    actions = ['merge_people']
+
     class Media:
         js = ['admin/viaf-lookup.js']
+
+    def merge_people(self, request, queryset):
+        '''Consolidate duplicate person records.'''
+        selected = request.POST.getlist(admin.ACTION_CHECKBOX_NAME)
+        return HttpResponseRedirect('%s?ids=%s' % \
+                (reverse('people:merge'), ','.join(selected)))
+    merge_people.short_description = 'Merge selected people'
 
 
 class LocationAdminForm(forms.ModelForm):

--- a/mep/people/admin.py
+++ b/mep/people/admin.py
@@ -131,6 +131,7 @@ class PersonAddressInline(AddressInline):
     fields = ('location', 'start_date', 'end_date', 'care_of_person', 'notes')
     fk_name = 'person'
 
+
 class PersonAdmin(admin.ModelAdmin):
     # NOTE: uses custom template to display relationships to this person
     # (only relationships to other people are edited here)
@@ -163,9 +164,13 @@ class PersonAdmin(admin.ModelAdmin):
 
     def merge_people(self, request, queryset):
         '''Consolidate duplicate person records.'''
+        # NOTE: using selected ids from form and ignoring queryset
+        # because this action is only meant for use with a few
+        # people at a time
         selected = request.POST.getlist(admin.ACTION_CHECKBOX_NAME)
         return HttpResponseRedirect('%s?ids=%s' % \
-                (reverse('people:merge'), ','.join(selected)))
+                (reverse('people:merge'), ','.join(selected)),
+                status=303)   # 303 = See Other
     merge_people.short_description = 'Merge selected people'
 
 

--- a/mep/people/forms.py
+++ b/mep/people/forms.py
@@ -19,8 +19,12 @@ class PersonMergeForm(forms.Form):
         empty_label=None, widget=forms.RadioSelect)
 
     def __init__(self, *args, **kwargs):
-        person_ids = kwargs.get('person_ids', None)
-        del kwargs['person_ids']
+        person_ids = kwargs.get('person_ids', [])
+        try:
+            del kwargs['person_ids']
+        except KeyError:
+            pass
+
         super().__init__(*args, **kwargs)
         self.fields['primary_person'].queryset = \
             Person.objects.filter(id__in=person_ids)

--- a/mep/people/forms.py
+++ b/mep/people/forms.py
@@ -1,0 +1,27 @@
+from django import forms
+from django.template.loader import get_template
+
+from mep.people.models import Person
+
+
+class PersonChoiceField(forms.ModelChoiceField):
+    label_template = get_template('people/snippets/person_option_label.html')
+
+    def label_from_instance(self, person):
+        return self.label_template.render({'person': person})
+
+
+class PersonMergeForm(forms.Form):
+    primary_person = PersonChoiceField(label='Primary record', queryset=None,
+        help_text='Select the person record to preserve. ' +
+                  'All events from other people will be reassociated with ' +
+                  'their account.',
+        empty_label=None, widget=forms.RadioSelect)
+
+    def __init__(self, *args, **kwargs):
+        person_ids = kwargs.get('person_ids', None)
+        del kwargs['person_ids']
+        super().__init__(*args, **kwargs)
+        self.fields['primary_person'].queryset = \
+            Person.objects.filter(id__in=person_ids)
+

--- a/mep/people/models.py
+++ b/mep/people/models.py
@@ -102,10 +102,10 @@ class PersonQuerySet(models.QuerySet):
         # error if person has no account
         # NOTE: could allow if nopeople in the queryset have accounts ...
         if not person.account_set.exists():
-            raise ObjectDoesNotExist("Can't merge with a person record that has no account")
+            raise ObjectDoesNotExist("Can't merge with a person record that has no account.")
         # error if more than account, since we can't pick which to merge to
         if person.account_set.count() > 1:
-            raise MultipleObjectsReturned("Can't merge with a person record that has multiple accounts")
+            raise MultipleObjectsReturned("Can't merge with a person record that has multiple accounts.")
         primary_account = person.account_set.first()
 
         # TODO: error if any accounts have more than one person associated

--- a/mep/people/models.py
+++ b/mep/people/models.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.contrib.contenttypes.fields import GenericRelation
-from django.db import models
+from django.db import models, transaction
 from viapy.api import ViafEntity
 
 from mep.common.models import AliasIntegerField, DateRange, Named, Notable
@@ -82,6 +82,7 @@ class Profession(Named, Notable):
 
 class PersonQuerySet(models.QuerySet):
 
+    @transaction.atomic
     def merge_with(self, person):
         '''Merge all person records in the current queryset with the
         specified person.  This entails the following:

--- a/mep/people/models.py
+++ b/mep/people/models.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from viapy.api import ViafEntity
@@ -79,6 +80,76 @@ class Profession(Named, Notable):
     pass
 
 
+class PersonQuerySet(models.QuerySet):
+
+    def merge_with(self, person):
+        '''Merge all person records in the current queryset with the
+        specified person.  This entails the following:
+            - all events from accounts associated with people in the
+              queryset are reassociated with the specified person
+            - all addresses associated with people in the
+              queryset or their accounts are reassociated with the
+              specified person or their account
+            - TODO: copy other details and update other relationships
+            - after data has been copied over, people in the queryset and
+              their accounts will be deleted
+
+        Raises an error if the specified person has more than one
+        account or if any people in the queryset have an account associated
+        with another person.
+        '''
+
+        # error if person has no account
+        # NOTE: could allow if nopeople in the queryset have accounts ...
+        if not person.account_set.exists():
+            raise ObjectDoesNotExist("Can't merge with a person record that has no account")
+        # error if more than account, since we can't pick which to merge to
+        if person.account_set.count() > 1:
+            raise MultipleObjectsReturned("Can't merge with a person record that has multiple accounts")
+        primary_account = person.account_set.first()
+
+        # TODO: error if any accounts have more than one person associated
+
+        # make sure specified person is skipped even if in the current queryset
+        merge_people = self.exclude(id=person.id)
+
+        for merge_person in merge_people:
+            for account in merge_person.account_set.all():
+                # reassociate all events with the main account
+                account.event_set.update(account=primary_account)
+                # reassociate any addresses with the main account
+                account.address_set.update(account=primary_account)
+                # delete the empty account
+                account.delete()
+
+            # update main person record with optional properties set on
+            # the copy if not already present on the main record
+            for attr in ['title', 'mep_id', 'birth_year', 'death_year',
+                         'viaf_id', 'sex', 'profession']:
+                # if not set on main person and set on merge person, copy
+                if not getattr(person, attr) and getattr(merge_person, attr):
+                    setattr(person, attr, getattr(merge_person, attr))
+            # append any notes
+            person.notes = '\n'.join(notes for notes in
+                [person.notes, merge_person.notes] if notes)
+            # reassociate related person data
+            # - personal addresses
+            merge_person.address_set.update(person=person)
+            # - nationalities
+            person.nationalities.add(*list(merge_person.nationalities.all()))
+            # - relations
+            merge_person.from_relationships.update(from_person=person)
+            merge_person.to_relationships.update(to_person=person)
+            # - info urls
+            merge_person.urls.update(person=person)
+            # - footnotes
+            merge_person.footnotes.update(object_id=person.id)
+
+        # delete the now-obsolete person records
+        merge_people.delete()
+        # save any attribute changes
+        person.save()
+
 
 class Person(Notable, DateRange):
     '''Model for people in the MEP dataset'''
@@ -130,6 +201,9 @@ class Person(Notable, DateRange):
     # we will probably use Address for most things
     locations = models.ManyToManyField(Location, through='accounts.Address',
         blank=True, through_fields=('person', 'location'))
+
+    # override default manager with customized version
+    objects = PersonQuerySet.as_manager()
 
     def __repr__(self):
         return '<Person %s>' % self.__dict__

--- a/mep/people/templates/people/merge_person.html
+++ b/mep/people/templates/people/merge_person.html
@@ -20,8 +20,8 @@
 
 {% block content %}
 <form method="post" style="padding-top: 2em;">
-    {% csrf_token %} {% if errors %}
-    <p class="errornote">{% if errors|length == 1 %}{% trans "Please correct the error below." %}{% else %}{% trans "Please correct the errors below." %}{% endif %}</p>
+    {% csrf_token %} {% if form.errors %}
+    <p class="errornote">Please correct the error{{ form.errors|pluralize}} below.</p>
     <ul class="errorlist">{% for error in form.non_field_errors %}
         <li>{{ error }}</li>{% endfor %}</ul>
     {% endif %}
@@ -33,6 +33,7 @@
                     {% if form.primary_person.help_text %} <p>{{ form.primary_person.help_text }}</p> {% endif %}
                 </div>
                 <div class="c-2">
+                    {{ form.primary_person.errors }}
                     {{ form.primary_person }}
                 </div>
             </div>

--- a/mep/people/templates/people/merge_person.html
+++ b/mep/people/templates/people/merge_person.html
@@ -1,0 +1,50 @@
+{% extends 'admin/base_site.html'  %}
+{% load i18n grp_tags %}
+{# Adapts Grappelli form styles for use in an intermediate view #}
+{% block title %} Merge selected people | {% get_site_title %} {% endblock %}
+
+{% block breadcrumbs %}
+    {% if not is_popup %}
+        <ul class="grp-horizontal-list">
+            <li><a href="{% url 'admin:index' %}">{% trans "Home" %}</a></li>
+            <li><a href="{% url 'admin:app_list' app_label='people' %}">Personography</a></li>
+            <li><a href="{% url 'admin:people_person_changelist'%}">People</a></li>
+            <li>Merge selected people</li>
+        </ul>
+    {% endif %}
+{% endblock %}
+
+{% block content_title %}
+    <h1>Merge selected people</h1>
+{% endblock %}
+
+{% block content %}
+<form method="post" style="padding-top: 2em;">
+    {% csrf_token %} {% if errors %}
+    <p class="errornote">{% if errors|length == 1 %}{% trans "Please correct the error below." %}{% else %}{% trans "Please correct the errors below." %}{% endif %}</p>
+    <ul class="errorlist">{% for error in form.non_field_errors %}
+        <li>{{ error }}</li>{% endfor %}</ul>
+    {% endif %}
+    <fieldset class="module grp-module">
+        <div class="form-row grp-row grp-cells-1">
+            <div class="field-box l-2c-fluid l-d-4">
+                <div class="c-1">
+                    <strong>{{ form.primary_person.label_tag|prettylabel }}</strong>
+                    {% if form.primary_person.help_text %} <p>{{ form.primary_person.help_text }}</p> {% endif %}
+                </div>
+                <div class="c-2">
+                    {{ form.primary_person }}
+                </div>
+            </div>
+        </div>
+
+        <div class="form-row grp-row grp-cells-1">
+            <div class="field-box l-2c-fluid l-d-4">
+                <input type="submit" value="Submit">
+            </div>
+        </div>
+
+    </fieldset>
+</form>
+
+{% endblock %}

--- a/mep/people/templates/people/snippets/person_option_label.html
+++ b/mep/people/templates/people/snippets/person_option_label.html
@@ -1,0 +1,62 @@
+<div class="merge-person-label">
+<strong>{{ person.title }} {{ person.name }}</strong>
+  {% if person.birth_year or person.death_year %}
+    {{ person.birth_year|default:'' }}–{{ person.death_year|default:'' }}
+  {% endif %}
+  {% if person.sex %}{{ person.display_sex_label }}{% endif %}
+  {% if person.mep_id %}<p>MEP id {{ person.mep_id }}</p>{% endif %}
+  {% if person.viaf %}<p>{{ person.viaf_id|urlize }}</p>{% endif %}
+  {% if person.notes %}<p class="notes">{{ person.notes }}</p>{% endif %}
+
+
+  {% for account in person.account_set.all %}
+    <div class="inline-group grp-group grp-tabular">
+        <h2 class="grp-collapse-handler"> {# link to account edit page #}
+            <a href="{% url 'admin:accounts_account_change' account.id %}">{{ account }}</a></h2>
+
+        {# display events similar to subscription display on person change form #}
+        {% if account.event_set.exists %}
+         <div class="tabular inline-related grp-module grp-table">
+            <div class="module grp-module grp-thead">
+                <div class="grp-tr">
+                    <div class="grp-th">Event</div>
+                    <div class="grp-th">Dates</div>
+                    <div class="grp-th">Notes</div>
+                </div>
+            </div>
+            <div class="form-row grp-module grp-tbody">
+                {% for event in account.event_set.all %}
+                {% if event.event_type != 'Borrow' and event.event_type != 'Purchase' %}
+                  <div class="grp-tr">
+                    <div class='grp-td'>
+                        {{ event.event_type }}
+                    </div>
+                    <div class="grp-td">
+                        {{ event.start_date }}{% if event.end_date != event.start_date %} - {{ event.end_date|default:'' }}{%endif %}
+                    </div>
+                    <div class='grp-td'>{{ event.notes }}</div>
+                </div>
+                {% endif %}
+                {% endfor %}
+                {# display borrowing and purchasing events together, after subscriptions & reimbursements #}
+                {% for event in account.event_set.all %}
+                {% if event.event_type == 'Borrow' or event.event_type == 'Purchase' %}
+                  <div class="grp-tr">
+                    <div class='grp-td'>
+                        {{ event.event_type }}
+                    </div>
+                    <div class="grp-td">
+                        {{ event.start_date }}{% if event.end_date != event.start_date %} - {{ event.end_date|default:'' }}{%endif %}
+                    </div>
+                    <div class='grp-td'>{{ event.notes }}</div>
+                </div>
+                {% endif %}
+                {% endfor %}
+            </div>
+        </div>
+        {% else %}
+        <div>No account events</div>
+        {% endif %}
+    </div>
+  {% endfor %}
+</div>

--- a/mep/people/templates/people/snippets/person_option_label.html
+++ b/mep/people/templates/people/snippets/person_option_label.html
@@ -1,3 +1,5 @@
+{# template snippet for displaying person label on a form  #}
+{# used on person merge form to provide enough information to merge accurately  #}
 <div class="merge-person-label">
 <strong>{{ person.title }} {{ person.name }}</strong>
   {% if person.birth_year or person.death_year %}
@@ -32,7 +34,7 @@
                         {{ event.event_type }}
                     </div>
                     <div class="grp-td">
-                        {{ event.start_date }}{% if event.end_date != event.start_date %} - {{ event.end_date|default:'' }}{%endif %}
+                        {{ event.start_date }}{% if event.end_date != event.start_date %}–{{ event.end_date|default:'' }}{%endif %}
                     </div>
                     <div class='grp-td'>{{ event.notes }}</div>
                 </div>
@@ -46,7 +48,7 @@
                         {{ event.event_type }}
                     </div>
                     <div class="grp-td">
-                        {{ event.start_date }}{% if event.end_date != event.start_date %} - {{ event.end_date|default:'' }}{%endif %}
+                        {{ event.start_date }}{% if event.end_date != event.start_date %}–{{ event.end_date|default:'' }}{%endif %}
                     </div>
                     <div class='grp-td'>{{ event.notes }}</div>
                 </div>

--- a/mep/people/tests/test_forms.py
+++ b/mep/people/tests/test_forms.py
@@ -54,7 +54,28 @@ class PersonChoiceFieldTest(TestCase):
         assert '%s–%s' % (format_date(borrow.start_date), format_date(borrow.end_date)) in label
 
 
+class PersonMergeFormTest(TestCase):
 
+    def test_init(self):
+        # no error if person ids not specified
+        PersonMergeForm()
+
+        # create test person records
+        Person.objects.bulk_create([
+            Person(name='Jones'),
+            Person(name='Jones', title='Mr'),
+            Person(name='Jones', title='Mr', sex='M'),
+            Person(name='Jones', title='Mrs'),
+        ])
+        # initialize with ids for all but the last
+        peeps = Person.objects.all().order_by('pk')
+        person_ids = list(peeps.values_list('id', flat=True))
+        mergeform = PersonMergeForm(person_ids=person_ids[:-1])
+        # total should have all but one person
+        assert mergeform.fields['primary_person'].queryset.count() == \
+            peeps.count() - 1
+        # last person should not be an available choice
+        assert peeps.last() not in mergeform.fields['primary_person'].queryset
 
 
 

--- a/mep/people/tests/test_forms.py
+++ b/mep/people/tests/test_forms.py
@@ -1,0 +1,60 @@
+import datetime
+from unittest.mock import Mock
+
+from django.test import TestCase
+from django.template.defaultfilters import date as format_date
+
+from mep.accounts.models import Account, Subscription, Borrow
+from mep.people.forms import PersonChoiceField, PersonMergeForm
+from mep.people.models import Person
+
+
+class PersonChoiceFieldTest(TestCase):
+
+    def test_label_from_instance(self):
+        pchoicefield = PersonChoiceField(Mock())
+
+        # should not error on record with minimal information
+        pers = Person.objects.create(name='Jones')
+        label = pchoicefield.label_from_instance(pers)
+        assert pers.name in label
+
+        # should display details if available
+        pers = Person.objects.create(name='Jones', title='Mr',
+            birth_year=1902, mep_id="jone", sex="M",
+            viaf_id='http://viaf.org/viaf/1902010101',
+            notes='more important details here')
+        label = pchoicefield.label_from_instance(pers)
+        assert '%s %s' % (pers.title, pers.name) in label
+        assert '%s–\n' % pers.birth_year in label
+        assert 'MEP id %s' % pers.mep_id in label
+        assert '<a href="%(url)s" rel="nofollow">%(url)s</a>' % {'url': pers.viaf_id} \
+            in label
+        assert pers.notes in label
+
+        # birth and death year when both are known
+        pers.death_year = 1956
+        label = pchoicefield.label_from_instance(pers)
+        assert '%s–%s' % (pers.birth_year, pers.death_year) in label
+
+        # display events if any
+        acct = Account.objects.create()
+        acct.persons.add(pers)
+        subs = Subscription.objects.create(account=acct,
+            start_date=datetime.datetime(1923, 1, 1), end_date=datetime.datetime(1924, 1, 1),
+            notes='img204c')
+        borrow = Borrow.objects.create(account=acct,
+            start_date=datetime.datetime(1923, 5, 1), end_date=datetime.datetime(1923, 5, 15))
+        label = pchoicefield.label_from_instance(pers)
+        assert 'Subscription' in label
+        # use template tag date format for consistency
+        assert '%s–%s' % (format_date(subs.start_date), format_date(subs.end_date)) in label
+        assert subs.notes in label
+        assert 'Borrow' in label
+        assert '%s–%s' % (format_date(borrow.start_date), format_date(borrow.end_date)) in label
+
+
+
+
+
+

--- a/mep/people/tests/test_models.py
+++ b/mep/people/tests/test_models.py
@@ -243,7 +243,8 @@ class TestPersonQuerySet(TestCase):
         assert main.sex == full.sex
         assert main.viaf_id == full.viaf_id
         assert main.profession == full.profession
-        assert main.notes == full.notes
+        assert full.notes in main.notes
+        assert 'Merged MEP id %s' % full.mep_id in main.notes
 
         # should _not_ copy over existing field values
         full2 = Person.objects.create(name='Jones',
@@ -255,7 +256,9 @@ class TestPersonQuerySet(TestCase):
         assert main.mep_id != full2.mep_id
         assert main.birth_year != full2.birth_year
         # notes should be appended
-        assert main.notes == "\n".join([full.notes, full2.notes])
+        assert full.notes in main.notes
+        assert full2.notes in main.notes
+        assert 'Merged MEP id %s' % full2.mep_id in main.notes
 
         # many-to-many relationships should be shifted to merged person record
         related = Person.objects.create(name='Jonesy')

--- a/mep/people/tests/test_models.py
+++ b/mep/people/tests/test_models.py
@@ -295,6 +295,17 @@ class TestPersonQuerySet(TestCase):
         assert parent_rel in main.to_relationships.all()
         assert fn in main.footnotes.all()
 
+        # person with account shared with another person
+        sib1 = Person.objects.create(name='sibling')
+        sib2 = Person.objects.create(name='sibling2')
+        acct = Account.objects.create()
+        acct.persons.add(sib1, sib2)
+
+        with pytest.raises(MultipleObjectsReturned) as err:
+            Person.objects.merge_with(main)
+        assert "Can't merge a person record with a shared account." in \
+            str(err)
+
 
 class TestProfession(TestCase):
 

--- a/mep/people/tests/test_views.py
+++ b/mep/people/tests/test_views.py
@@ -1,20 +1,22 @@
 import json
 from datetime import date
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
+from django.contrib.messages import get_messages
 from django.contrib.auth.models import User
 from django.http import JsonResponse
 from django.template.defaultfilters import date as format_date
 from django.test import TestCase
-from django.urls import reverse
+from django.urls import reverse, resolve
 
 from mep.accounts.models import Account, Address, Event, Subscription, \
     Reimbursement
 from mep.people.admin import GeoNamesLookupWidget, MapWidget
+from mep.people.forms import PersonMergeForm
 from mep.people.geonames import GeoNamesAPI
 from mep.people.models import Location, Country, Person, Relationship, \
     RelationshipType
-from mep.people.views import GeoNamesLookup
+from mep.people.views import GeoNamesLookup, PersonMerge
 
 
 class TestPeopleViews(TestCase):
@@ -239,6 +241,66 @@ class TestPeopleViews(TestCase):
         self.assertContains(result, Person.list_nationalities.short_description,
             msg_prefix='should have list_nationalities field and short desc.')
 
+    def test_person_merge(self):
+        # TODO: permissions required (add permission check, test)
+
+        su_password = 'itsasecret'
+        superuser = User.objects.create_superuser(username='admin',
+            password=su_password, email='su@example.com')
+
+        # login as admin user
+        self.client.login(username=superuser.username, password=su_password)
+
+         # create test person records to merge
+        pers = Person.objects.create(name='M. Jones')
+        pers2 = Person.objects.create(name='Mike Jones')
+
+        person_ids = [pers.id, pers2.id]
+        idstring = ','.join(str(pid) for pid in person_ids)
+
+        # GET should display choices
+        response = self.client.get(reverse('people:merge'), {'ids': idstring})
+        # sanity check form and display (components tested elsewhere)
+        assert isinstance(response.context['form'], PersonMergeForm)
+        template_names = [tpl.name for tpl in response.templates]
+        assert 'people/merge_person.html' in template_names
+        self.assertContains(response, pers.name)
+        self.assertContains(response, pers2.name)
+
+        # POST should attempt to merge - error message should be reported
+        response = self.client.post('%s?ids=%s' % \
+                                    (reverse('people:merge'), idstring),
+                                    {'primary_person': pers.id},
+                                    follow=True)
+        self.assertRedirects(response, reverse('admin:people_person_changelist'))
+        message = list(response.context.get('messages'))[0]
+        assert message.tags == 'error'
+        assert "Can't merge with a person record that has no account." \
+            == message.message
+
+        # add accounts and events
+        acct = Account.objects.create()
+        acct.persons.add(pers)
+        acct2 = Account.objects.create()
+        acct2.persons.add(pers2)
+        Subscription.objects.create(account=acct2)
+        response = self.client.post('%s?ids=%s' % \
+                                    (reverse('people:merge'), idstring),
+                                    {'primary_person': pers.id},
+                                    follow=True)
+        message = list(response.context.get('messages'))[0]
+        assert message.tags == 'success'
+        assert 'Reassociated 1 event ' in message.message
+        assert pers.name in message.message
+        assert str(acct) in message.message
+        assert reverse('admin:people_person_change', args=[pers.id]) \
+            in message.message
+        assert reverse('admin:accounts_account_change', args=[acct.id]) \
+            in message.message
+        # confirm merge completed by checking objects were removed
+        assert not Account.objects.filter(id=acct2.id).exists()
+        assert not Person.objects.filter(id=pers2.id).exists()
+
 
 class TestGeonamesLookup(TestCase):
 
@@ -368,3 +430,29 @@ class TestLocationAutocompleteView(TestCase):
         info = res.json()
         assert len(info['results']) == 1
         assert 'Hotel Le Foo' in info['results'][0]['text']
+
+
+class TestPersonMergeView(TestCase):
+
+    def test_get_success_url(self):
+        resolved_url = resolve(PersonMerge().get_success_url())
+        assert 'admin' in resolved_url.app_names
+        assert resolved_url.url_name == 'people_person_changelist'
+
+    def test_get_initial(self):
+        pmview = PersonMerge()
+        pmview.request = Mock(GET={'ids': '12,23,456,7'})
+
+        initial = pmview.get_initial()
+        assert pmview.person_ids == [12, 23, 456, 7]
+        # lowest id selected as default primary person
+        assert initial['primary_person'] == 7
+
+    def test_get_form_kwargs(self):
+        pmview = PersonMerge()
+        pmview.request = Mock(GET={'ids': '12,23,456,7'})
+        form_kwargs = pmview.get_form_kwargs()
+        assert form_kwargs['person_ids'] == pmview.person_ids
+
+    # form_valid method tested through client post request above
+

--- a/mep/people/urls.py
+++ b/mep/people/urls.py
@@ -1,19 +1,18 @@
 from django.conf.urls import url
 
-from mep.people.views import GeoNamesLookup, PersonAutocomplete, \
-    CountryAutocomplete, LocationAutocomplete
+from mep.people import views
 
 
 urlpatterns = [
-    url(r'^places/geonames/$', GeoNamesLookup.as_view(),
+    url(r'^places/geonames/$', views.GeoNamesLookup.as_view(),
         name='geonames-lookup'),
-    url(r'^places/geonames/country/$', GeoNamesLookup.as_view(),
+    url(r'^places/geonames/country/$', views.GeoNamesLookup.as_view(),
         {'mode': 'country'}, name='country-lookup'),
-    url(r'^people/autocomplete/$', PersonAutocomplete.as_view(),
+    url(r'^people/autocomplete/$', views.PersonAutocomplete.as_view(),
         name='autocomplete'),
-    url(r'^people/country/autocomplete', CountryAutocomplete.as_view(),
+    url(r'^people/country/autocomplete', views.CountryAutocomplete.as_view(),
         name='country-autocomplete'),
-    url(r'^people/location/autocomplete', LocationAutocomplete.as_view(),
-        name='location-autocomplete')
-
+    url(r'^people/location/autocomplete', views.LocationAutocomplete.as_view(),
+        name='location-autocomplete'),
+    url(r'^people/merge/$', views.PersonMerge.as_view(), name='merge'),
 ]

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -173,7 +173,8 @@ class PersonMerge(FormView):
         # default to first person selected (?)
         # _could_ add logic to select most complete record,
         # but probably better for team members to choose
-        self.person_ids = [int(pid) for pid in self.request.GET.getlist('ids')]
+        self.person_ids = [int(pid) for pid in
+                           self.request.GET.get('ids', '').split(',')]
         # by default, prefer the first record created
         return {'primary_person': sorted(self.person_ids)[0]}
 

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -195,8 +195,9 @@ class PersonMerge(FormView):
             # is this a useful metric? potentially doing a lot more than that...
             added_events = primary_account.event_set.count() - existing_events
             messages.success(self.request,
-                mark_safe('Reassociated %d events with <a href="%s">%s</a> (<a href="%s">%s</a>).'
+                mark_safe('Reassociated %d event%s with <a href="%s">%s</a> (<a href="%s">%s</a>).'
              % (added_events,
+                's' if added_events != 1 else '',
                 reverse('admin:people_person_change', args=[primary_person.id]),
                 primary_person,
                 reverse('admin:accounts_account_change', args=[primary_account.id]),

--- a/mep/urls.py
+++ b/mep/urls.py
@@ -6,6 +6,9 @@ from django.contrib import admin
 from django.views.generic.base import RedirectView
 import mezzanine.urls
 
+from mep.people import urls as people_urls
+from mep.accounts import urls as accounts_urls
+
 urlpatterns = [
     # for now, since there is not yet any public-facing site,
     # redirect base url to admin index page
@@ -14,8 +17,8 @@ urlpatterns = [
     url(r'^grappelli/', include('grappelli.urls')),
     url(r'^accounts/', include('pucas.cas_urls')),
     url(r'^viaf/', include('viapy.urls', namespace='viaf')),
-    url(r'^', include('mep.people.urls', namespace='people')),
-    url(r'^', include('mep.accounts.urls', namespace='accounts')),
+    url(r'^', include(people_urls, namespace='people')),
+    url(r'^', include(accounts_urls, namespace='accounts')),
 
     # content pages managed by mezzanine
     url(r'^', include(mezzanine.urls))

--- a/sitemedia/css/local.css
+++ b/sitemedia/css/local.css
@@ -5,3 +5,19 @@
     font-style: small;
     border-left: black solid 1px;
 }
+
+/* styles for merge person form */
+#id_primary_person label {
+    width: 90%;
+}
+
+#id_primary_person input {
+    float: left;
+}
+.merge-person-label {
+    margin-left: 25px;
+}
+
+.merge-person-label .notes {
+    white-space: pre;
+}


### PR DESCRIPTION
Custom admin action to merge duplicate people records in the personography.  Combines account and person data into the selected primary person record, and deletes the merged account and person records.  More details in #72.

Does not yet include tests for the merge view; but with the refactor to move the actual merge logic into a queryset method (which is now fully tested), that should be relatively straightforward.