### PR TITLE
allow merging people without accounts (#109)

### DIFF
--- a/mep/people/models.py
+++ b/mep/people/models.py
@@ -103,18 +103,14 @@ class PersonQuerySet(models.QuerySet):
         with another person.
 
         :param person: :class:`Person` person
-        :raises django.core.exceptions.ObjectDoesNotExist:
-            if selected :class:`Person` has no account
         :raises django.core.exceptions.MultipleObjectsReturned:
             if selected :class:`Person` has multiple accounts _or_ any person
             in the queryset has an account shared with another person
         '''
 
-        # error if person has no account
-        # NOTE: technically could allow person with no account if no
-        # people in the queryset have accounts, but currently not supported
-        if not person.account_set.exists():
-            raise ObjectDoesNotExist("Can't merge with a person record that has no account.")
+        # identify the account other events will be reassociated with, if exists
+        if person.has_account():
+            primary_account = person.account_set.first()
         # error if more than account, since we can't pick which to merge to
         if person.account_set.count() > 1:
             raise MultipleObjectsReturned("Can't merge with a person record that has multiple accounts.")
@@ -123,19 +119,28 @@ class PersonQuerySet(models.QuerySet):
                .filter(account_people__gt=1).exists():
             raise MultipleObjectsReturned("Can't merge a person record with a shared account.")
 
-        # identify the account other events will be reassociated with
-        primary_account = person.account_set.first()
         # make sure specified person is skipped even if in the current queryset
         merge_people = self.exclude(id=person.id)
 
         for merge_person in merge_people:
-            for account in merge_person.account_set.all():
-                # reassociate all events with the main account
-                account.event_set.update(account=primary_account)
-                # reassociate any addresses with the main account
-                account.address_set.update(account=primary_account)
-                # delete the empty account
-                account.delete()
+            if merge_person.has_account():
+            # if the merged person had an account
+                if person.has_account():
+                    # *and* if the main person had an account
+                    for account in merge_person.account_set.all():
+                        # reassociate all events with the main account
+                        account.event_set.update(account=primary_account)
+                        # reassociate any addresses with the main account
+                        account.address_set.update(account=primary_account)
+                        # delete the empty account
+                        account.delete()
+                else:
+                # a merged person had an account, but the main person doesn't
+                    for account in merge_person.account_set.all():
+                        # swap the account's owner to the main person
+                        account.persons.add(person)
+                        account.persons.remove(merge_person)
+
 
             # update main person record with optional properties set on
             # the copy if not already present on the main record

--- a/mep/people/tests/test_models.py
+++ b/mep/people/tests/test_models.py
@@ -186,11 +186,6 @@ class TestPersonQuerySet(TestCase):
 
         # use Jonas as record to merge others to
         main_person = Person.objects.get(name='Jonas')
-        # person to merge with has no account - error
-        with pytest.raises(ObjectDoesNotExist) as err:
-            Person.objects.merge_with(main_person)
-        assert "Can't merge with a person record that has no account" in \
-            str(err)
 
         # create accounts with content to merge
         main_acct = Account.objects.create()
@@ -326,6 +321,18 @@ class TestPersonQuerySet(TestCase):
             Person.objects.merge_with(main)
         assert "Can't merge a person record with a shared account." in \
             str(err)
+
+        # main person with no account data should work normally; other accounts
+        # will be converted to their ownership
+        mike = Person.objects.create(name='Mike Mulshine')
+        spencer = Person.objects.create(name='Spencer Hadley', birth_year=1990)
+        spencer_acct = Account.objects.create()
+        spencer_acct.persons.add(spencer)
+        Person.objects.filter(pk=spencer.id).merge_with(mike)
+        assert mike.name == 'Mike Mulshine'
+        assert mike.birth_year == 1990
+        assert spencer_acct in mike.account_set.all()
+
 
 
 class TestProfession(TestCase):

--- a/mep/people/tests/test_views.py
+++ b/mep/people/tests/test_views.py
@@ -335,6 +335,21 @@ class TestPeopleViews(TestCase):
             in message.message
         assert not Person.objects.filter(id=pers4.id).exists()
 
+        # Merging with shared account should fail
+        mike = Person.objects.create(name='Mike Mulshine')
+        spencer = Person.objects.create(name='Spencer Hadley')
+        nikitas = Person.objects.create(name='Nikitas Tampakis')
+        shared_acct = Account.objects.create()
+        shared_acct.persons.add(mike)
+        shared_acct.persons.add(spencer)
+        idstring = ','.join(str(pid) for pid in [mike.id, spencer.id, nikitas.id])
+        response = self.client.post('%s?ids=%s' % \
+                                    (reverse('people:merge'), idstring),
+                                    {'primary_person': mike.id},
+                                    follow=True)
+        message = list(response.context.get('messages'))[0]
+        assert message.tags == 'error'
+        assert 'shared account' in message.message
 
 class TestGeonamesLookup(TestCase):
 

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -211,7 +211,8 @@ class PersonMerge(PermissionRequiredMixin, FormView):
 
         # user-selected person record to keep
         primary_person = form.cleaned_data['primary_person']
-        if primary_person.account_set.exists():
+
+        if primary_person.has_account():
             primary_account = primary_person.account_set.first()
             existing_events = primary_account.event_set.count()
 
@@ -220,19 +221,25 @@ class PersonMerge(PermissionRequiredMixin, FormView):
             Person.objects.filter(id__in=self.person_ids) \
                           .merge_with(primary_person)
 
-            # is this a useful metric? potentially doing a lot more than that...
-            added_events = primary_account.event_set.count() - existing_events
-            messages.success(self.request,
-                mark_safe('Reassociated %d event%s with <a href="%s">%s</a> (<a href="%s">%s</a>).'
-             % (added_events,
-                's' if added_events != 1 else '',
-                reverse('admin:people_person_change', args=[primary_person.id]),
-                primary_person,
-                reverse('admin:accounts_account_change', args=[primary_account.id]),
-                primary_account)))
+            if primary_person.has_account():
+                # is this a useful metric? potentially doing a lot more than that...
+                added_events = primary_account.event_set.count() - existing_events
+                messages.success(self.request,
+                    mark_safe('Reassociated %d event%s with <a href="%s">%s</a> (<a href="%s">%s</a>).'
+                % (added_events,
+                    's' if added_events != 1 else '',
+                    reverse('admin:people_person_change', args=[primary_person.id]),
+                    primary_person,
+                    reverse('admin:accounts_account_change', args=[primary_account.id]),
+                    primary_account)))
+            else: # no accounts merged
+                messages.success(self.request,
+                    mark_safe('Merge for <a href="%s">%s</a> complete; no accounts to reassociate.'
+                    % (reverse('admin:people_person_change', args=[primary_person.id]),
+                    primary_person)))
 
-        # error if person has more than one account, no account
-        except (ObjectDoesNotExist, MultipleObjectsReturned) as err:
+        # error if person has more than one account
+        except MultipleObjectsReturned as err:
             messages.error(self.request, str(err))
 
         return super(PersonMerge, self).form_valid(form)

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -211,8 +211,9 @@ class PersonMerge(PermissionRequiredMixin, FormView):
 
         # user-selected person record to keep
         primary_person = form.cleaned_data['primary_person']
+        existing_events = 0
 
-        if primary_person.has_account():
+        if primary_person.has_account(): # get existing events, if any
             primary_account = primary_person.account_set.first()
             existing_events = primary_account.event_set.count()
 
@@ -223,6 +224,7 @@ class PersonMerge(PermissionRequiredMixin, FormView):
 
             if primary_person.has_account():
                 # is this a useful metric? potentially doing a lot more than that...
+                primary_account = primary_person.account_set.first() # if there wasn't one before
                 added_events = primary_account.event_set.count() - existing_events
                 messages.success(self.request,
                     mark_safe('Reassociated %d event%s with <a href="%s">%s</a> (<a href="%s">%s</a>).'


### PR DESCRIPTION
refs #109 

- people without accounts can be merged into other people with accounts
- people without accounts can have other people's accounts merged "into" them (ownership transfers to the target of the merge)
- if no accounts were involved in the merge, the merge tool will display a message notifying you that no accounts were reassigned but the merge was successfully completed