### PR TITLE
Script to generate a report on OCLC item reconciliation

### DIFF
--- a/DEPLOYNOTES.rst
+++ b/DEPLOYNOTES.rst
@@ -3,6 +3,13 @@
 Deploy and Upgrade notes
 ========================
 
+0.14
+----
+
+* You must configure **OCLC_WSKEY** in ``localsettings.py`` before
+  you can use the new ``reconcile_oclc`` manage command. You should
+  also configure a TECHNICAL_CONTACT email address.
+
 0.13
 ----
 

--- a/mep/accounts/admin.py
+++ b/mep/accounts/admin.py
@@ -6,8 +6,9 @@ from django import forms
 from django.contrib import admin
 from django.core.validators import RegexValidator, ValidationError
 
+from mep.accounts.partial_date import DatePrecision, PartialDate
 from mep.accounts.models import Account, Address, Subscription,\
-    Reimbursement, Event, SubscriptionType, Borrow, PartialDate, Purchase
+    Reimbursement, Event, SubscriptionType, Borrow, Purchase
 from mep.common.admin import NamedNotableAdmin, CollapsibleTabularInline
 from mep.footnotes.admin import FootnoteInline
 

--- a/mep/accounts/migrations/0016_add_borrow_date_precision.py
+++ b/mep/accounts/migrations/0016_add_borrow_date_precision.py
@@ -16,11 +16,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='borrow',
             name='end_date_precision',
-            field=mep.accounts.models.DatePrecisionField(default=7),
+            field=mep.accounts.partial_date.DatePrecisionField(default=7),
         ),
         migrations.AddField(
             model_name='borrow',
             name='start_date_precision',
-            field=mep.accounts.models.DatePrecisionField(default=7),
+            field=mep.accounts.partial_date.DatePrecisionField(default=7),
         ),
     ]

--- a/mep/accounts/migrations/0019_allow_null_precision.py
+++ b/mep/accounts/migrations/0019_allow_null_precision.py
@@ -16,11 +16,11 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='borrow',
             name='end_date_precision',
-            field=mep.accounts.models.DatePrecisionField(blank=True, null=True),
+            field=mep.accounts.partial_date.DatePrecisionField(blank=True, null=True),
         ),
         migrations.AlterField(
             model_name='borrow',
             name='start_date_precision',
-            field=mep.accounts.models.DatePrecisionField(blank=True, null=True),
+            field=mep.accounts.partial_date.DatePrecisionField(blank=True, null=True),
         ),
     ]

--- a/mep/accounts/migrations/0022_add_partial_date_purchase.py
+++ b/mep/accounts/migrations/0022_add_partial_date_purchase.py
@@ -17,12 +17,12 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='purchase',
             name='end_date_precision',
-            field=mep.accounts.models.DatePrecisionField(blank=True, null=True),
+            field=mep.accounts.partial_date.DatePrecisionField(blank=True, null=True),
         ),
         migrations.AddField(
             model_name='purchase',
             name='start_date_precision',
-            field=mep.accounts.models.DatePrecisionField(blank=True, null=True),
+            field=mep.accounts.partial_date.DatePrecisionField(blank=True, null=True),
         ),
         migrations.AlterField(
             model_name='account',

--- a/mep/accounts/models.py
+++ b/mep/accounts/models.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import re
 import datetime
 from itertools import chain
 
@@ -10,8 +9,8 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import ValidationError
 from django.db import models
 from django.template.defaultfilters import pluralize
-from flags import Flags
 
+from mep.accounts.partial_date import PartialDateMixin
 from mep.books.models import Item
 from mep.common.models import Named, Notable
 from mep.people.models import Person, Location
@@ -462,189 +461,6 @@ class Subscription(Event, CurrencyMixin):
     readable_duration.short_description = 'Duration'
     readable_duration.admin_order_field = 'duration'
 
-
-class DatePrecision(Flags):
-    '''Flag class to indicate which parts of a date are known.'''
-    year = ()
-    month = ()
-    day = ()
-
-
-class DatePrecisionField(models.PositiveSmallIntegerField):
-    '''Integer representation of a :class:`DatePrecision`.'''
-    description = 'Integer representation of DatePrecision flags.'
-
-    def to_python(self, value):
-        return DatePrecision(value) if value else None
-
-
-class PartialDate(object):
-    '''Descriptor that gets and sets a related :class:`datetime.date` and
-    :class:`DatePrecision` from partial date strings, e.g. --05-02.'''
-
-    description = 'Partial date generated from date and date precision flags'
-
-    partial_date_re = re.compile(
-       r'^(?P<year>\d{4}|-)?(?:-(?P<month>[01]\d))?(?:-(?P<day>[0-3]\d))?$'
-    )
-
-    def __init__(self, date_field, date_precision_field, unknown_year:int=1,
-                 label=None):
-        self.date_field = date_field
-        self.date_precision_field = date_precision_field
-        self.unknown_year = unknown_year
-
-        # set attributes for display/sort in django admin
-        self.admin_order_field = date_field
-        if label:
-            self.short_description = label
-
-    def __get__(self, obj, objtype=None):
-        '''Use :meth:`date_format` to transform a  :class:`datetime.date` and
-        :class:`DatePrecision` to a partial date string. If the date doesn't
-        exist yet, return None.'''
-        if obj is None:
-            return self
-        date_val = getattr(obj, self.date_field, None)
-        if date_val:
-            date_precision_val = getattr(obj, self.date_precision_field)
-            return date_val.strftime(self.date_format(date_precision_val))
-
-    def __set__(self, obj, val):
-        '''Call :meth:`parse_date` to parse a partial date and set the
-        :class:`datetime.date` and :class:`DatePrecision`. If a falsy value was
-        passed, set them both to None.'''
-        (date_val, date_precision_val) = self.parse_date(val) if val else (None, None)
-        setattr(obj, self.date_field, date_val)
-        setattr(obj, self.date_precision_field, date_precision_val)
-
-    @staticmethod
-    def date_format(value):
-        '''Return a format string for use with :meth:`datetime.date.strftime`
-        to output a date with the appropriate precision'''
-        parts = []
-        # cast integer to date precision to check flags
-        value = DatePrecision(value)
-
-        # no precision = no date
-        if not value:
-            return ''
-
-        if value.year:
-            parts.append('%Y')
-        else:
-            # if no year, indicate with --
-            parts.append('-')
-        if value.month:
-            parts.append('%m')
-        if value.day:
-            parts.append('%d')
-
-        # this is potentially ambiguous in some cases, but those cases
-        # may not be meaningful anyway
-        return '-'.join(parts)
-
-    def parse_date(self, value):
-        '''Parse a partial date string and return a :class:`datetime.date`
-        and precision value.'''
-        # partial date parsing adapted in part from django_partial_date
-        # https://github.com/ktowen/django_partial_date
-        match = self.partial_date_re.match(value)
-        if match:
-            match_info = match.groupdict()
-
-            # turn matched values into numbers for initializing date object
-            date_values = {}
-            date_parts = []
-            for k, v in match_info.items():
-                try:
-                    date_values[k] = int(v)
-                    date_parts.append(k)
-                except (TypeError, ValueError): # value was None or '-'
-                    date_values[k] = self.unknown_year if k == 'year' else 1
-
-            if date_parts == ['day'] or date_parts == ['month'] or date_parts == ['year', 'day']:
-                raise ValidationError('"%s" is not a recognized date.''' % value)
-
-            # determine known date parts based on regex match values
-            # and initialize pecision flags accordingly
-            precision = DatePrecision.from_simple_str('|'.join(date_parts))
-            return (datetime.date(**date_values), precision)
-
-        else:
-            raise ValidationError('"%s" is not a recognized date.''' % value)
-
-
-class PartialDateMixin(models.Model):
-    '''Mixin to add fields for partial start and end dates to a model using
-    :class:`DatePrecisionField` and :class:`PartialDate`.'''
-    UNKNOWN_YEAR = 1900
-
-    start_date_precision = DatePrecisionField(null=True, blank=True)
-    end_date_precision = DatePrecisionField(null=True, blank=True)
-    partial_start_date = PartialDate('start_date', 'start_date_precision',
-        UNKNOWN_YEAR, label='start date')
-    partial_end_date = PartialDate('end_date', 'end_date_precision',
-        UNKNOWN_YEAR, label='end date')
-
-    class Meta:
-        abstract = True
-
-    def calculate_date(self, kind, dateval=None, earliest=None, latest=None):
-        '''Calculate end or start date based on a single value in a
-        supported partial date form or based on earliest/latest datetime.'''
-
-        # kind must be either start_date or end_date
-        if kind not in ['start_date', 'end_date']:
-            raise ValueError
-
-        # if there is a single date value, use partial date to parse it
-        # and set date precision
-        if dateval:
-            setattr(self, 'partial_%s' % kind, dateval)
-            # special case:
-            # 1900 dates were used to indicate unknown year; book store didn't
-            # open until 1919, so any year before that should be marked unknown
-            if getattr(self, kind).year < 1919:
-                setattr(self, '%s_precision' % kind,
-                        DatePrecision.month | DatePrecision.day)
-
-        # no exact date, but earliest/latest possible dates
-        elif earliest and latest:
-            # store earliest datetime
-            setattr(self, kind, earliest)
-            precision = DatePrecision()
-            # calculate the precision based on values in common
-            if earliest.year == latest.year:
-                precision |= DatePrecision.year
-            if earliest.month == latest.month:
-                precision |= DatePrecision.month
-            if earliest.day == latest.day:
-                precision |= DatePrecision.day
-
-            # store the precision
-            setattr(self, '%s_precision' % kind, precision)
-
-    @property
-    def date_range(self):
-        '''Borrowing event date range as string, using partial dates.
-        Returns a single date in partial date format if both dates are
-        set to the same date. Uses "??" for unset dates,
-        and returns in format start/end.'''
-
-        # NOTE: this is the same logic as the Event date range method,
-        # just substituting partial start and end dates and dropping the
-        # isoformat method call.
-
-        # if both dates are set and the same, return a single date
-        if self.partial_start_date and self.partial_end_date and \
-                self.partial_start_date == self.partial_end_date:
-            return self.partial_start_date
-
-        # otherwise, use both dates with ?? to indicate unknown date
-        return '/'.join([dt if dt else '??'
-                         for dt in [self.partial_start_date,
-                                    self.partial_end_date]])
 
 
 class Borrow(PartialDateMixin, Event):

--- a/mep/accounts/partial_date.py
+++ b/mep/accounts/partial_date.py
@@ -201,6 +201,8 @@ class KnownYear(models.Lookup):
 
         bit_compare = "%s & %d" % (lhs, int(DatePrecision.year))
         # if true (year is known), precision should be null or year bit set
+        # (has to include null check since field is currently configured
+        # to allow null rather than defaulting to full precision)
         if self.rhs:
             return "%s IS NULL OR %s != 0" % (lhs, bit_compare), params
 

--- a/mep/accounts/partial_date.py
+++ b/mep/accounts/partial_date.py
@@ -1,0 +1,190 @@
+import re
+import datetime
+
+from django.db import models
+from django.core.validators import ValidationError
+from flags import Flags
+
+
+class DatePrecision(Flags):
+    '''Flag class to indicate which parts of a date are known.'''
+    year = ()
+    month = ()
+    day = ()
+
+
+class DatePrecisionField(models.PositiveSmallIntegerField):
+    '''Integer representation of a :class:`DatePrecision`.'''
+    description = 'Integer representation of DatePrecision flags.'
+
+    def to_python(self, value):
+        return DatePrecision(value) if value else None
+
+
+class PartialDate:
+    '''Descriptor that gets and sets a related :class:`datetime.date` and
+    :class:`DatePrecision` from partial date strings, e.g. --05-02.'''
+
+    description = 'Partial date generated from date and date precision flags'
+
+    partial_date_re = re.compile(
+       r'^(?P<year>\d{4}|-)?(?:-(?P<month>[01]\d))?(?:-(?P<day>[0-3]\d))?$'
+    )
+
+    def __init__(self, date_field, date_precision_field, unknown_year:int=1,
+                 label=None):
+        self.date_field = date_field
+        self.date_precision_field = date_precision_field
+        self.unknown_year = unknown_year
+
+        # set attributes for display/sort in django admin
+        self.admin_order_field = date_field
+        if label:
+            self.short_description = label
+
+    def __get__(self, obj, objtype=None):
+        '''Use :meth:`date_format` to transform a  :class:`datetime.date` and
+        :class:`DatePrecision` to a partial date string. If the date doesn't
+        exist yet, return None.'''
+        if obj is None:
+            return self
+        date_val = getattr(obj, self.date_field, None)
+        if date_val:
+            date_precision_val = getattr(obj, self.date_precision_field)
+            return date_val.strftime(self.date_format(date_precision_val))
+
+    def __set__(self, obj, val):
+        '''Call :meth:`parse_date` to parse a partial date and set the
+        :class:`datetime.date` and :class:`DatePrecision`. If a falsy value was
+        passed, set them both to None.'''
+        (date_val, date_precision_val) = self.parse_date(val) if val else (None, None)
+        setattr(obj, self.date_field, date_val)
+        setattr(obj, self.date_precision_field, date_precision_val)
+
+    @staticmethod
+    def date_format(value):
+        '''Return a format string for use with :meth:`datetime.date.strftime`
+        to output a date with the appropriate precision'''
+        parts = []
+        # cast integer to date precision to check flags
+        value = DatePrecision(value)
+
+        # no precision = no date
+        if not value:
+            return ''
+
+        if value.year:
+            parts.append('%Y')
+        else:
+            # if no year, indicate with --
+            parts.append('-')
+        if value.month:
+            parts.append('%m')
+        if value.day:
+            parts.append('%d')
+
+        # this is potentially ambiguous in some cases, but those cases
+        # may not be meaningful anyway
+        return '-'.join(parts)
+
+    def parse_date(self, value):
+        '''Parse a partial date string and return a :class:`datetime.date`
+        and precision value.'''
+        # partial date parsing adapted in part from django_partial_date
+        # https://github.com/ktowen/django_partial_date
+        match = self.partial_date_re.match(value)
+        if match:
+            match_info = match.groupdict()
+
+            # turn matched values into numbers for initializing date object
+            date_values = {}
+            date_parts = []
+            for k, v in match_info.items():
+                try:
+                    date_values[k] = int(v)
+                    date_parts.append(k)
+                except (TypeError, ValueError): # value was None or '-'
+                    date_values[k] = self.unknown_year if k == 'year' else 1
+
+            if date_parts == ['day'] or date_parts == ['month'] or date_parts == ['year', 'day']:
+                raise ValidationError('"%s" is not a recognized date.''' % value)
+
+            # determine known date parts based on regex match values
+            # and initialize pecision flags accordingly
+            precision = DatePrecision.from_simple_str('|'.join(date_parts))
+            return (datetime.date(**date_values), precision)
+
+        else:
+            raise ValidationError('"%s" is not a recognized date.''' % value)
+
+
+class PartialDateMixin(models.Model):
+    '''Mixin to add fields for partial start and end dates to a model using
+    :class:`DatePrecisionField` and :class:`PartialDate`.'''
+    UNKNOWN_YEAR = 1900
+
+    start_date_precision = DatePrecisionField(null=True, blank=True)
+    end_date_precision = DatePrecisionField(null=True, blank=True)
+    partial_start_date = PartialDate(
+        'start_date', 'start_date_precision', UNKNOWN_YEAR, label='start date')
+    partial_end_date = PartialDate(
+        'end_date', 'end_date_precision', UNKNOWN_YEAR, label='end date')
+
+    class Meta:
+        abstract = True
+
+    def calculate_date(self, kind, dateval=None, earliest=None, latest=None):
+        '''Calculate end or start date based on a single value in a
+        supported partial date form or based on earliest/latest datetime.'''
+
+        # kind must be either start_date or end_date
+        if kind not in ['start_date', 'end_date']:
+            raise ValueError
+
+        # if there is a single date value, use partial date to parse it
+        # and set date precision
+        if dateval:
+            setattr(self, 'partial_%s' % kind, dateval)
+            # special case:
+            # 1900 dates were used to indicate unknown year; book store didn't
+            # open until 1919, so any year before that should be marked unknown
+            if getattr(self, kind).year < 1919:
+                setattr(self, '%s_precision' % kind,
+                        DatePrecision.month | DatePrecision.day)
+
+        # no exact date, but earliest/latest possible dates
+        elif earliest and latest:
+            # store earliest datetime
+            setattr(self, kind, earliest)
+            precision = DatePrecision()
+            # calculate the precision based on values in common
+            if earliest.year == latest.year:
+                precision |= DatePrecision.year
+            if earliest.month == latest.month:
+                precision |= DatePrecision.month
+            if earliest.day == latest.day:
+                precision |= DatePrecision.day
+
+            # store the precision
+            setattr(self, '%s_precision' % kind, precision)
+
+    @property
+    def date_range(self):
+        '''Borrowing event date range as string, using partial dates.
+        Returns a single date in partial date format if both dates are
+        set to the same date. Uses "??" for unset dates,
+        and returns in format start/end.'''
+
+        # NOTE: this is the same logic as the Event date range method,
+        # just substituting partial start and end dates and dropping the
+        # isoformat method call.
+
+        # if both dates are set and the same, return a single date
+        if self.partial_start_date and self.partial_end_date and \
+                self.partial_start_date == self.partial_end_date:
+            return self.partial_start_date
+
+        # otherwise, use both dates with ?? to indicate unknown date
+        return '/'.join([dt if dt else '??'
+                         for dt in [self.partial_start_date,
+                                    self.partial_end_date]])

--- a/mep/accounts/tests/test_accounts_admin.py
+++ b/mep/accounts/tests/test_accounts_admin.py
@@ -3,7 +3,8 @@ import datetime
 from dateutil.relativedelta import relativedelta
 from django.test import TestCase
 
-from mep.accounts.models import Account, Subscription, Borrow, DatePrecision, \
+from mep.accounts.partial_date import DatePrecision
+from mep.accounts.models import Account, Subscription, Borrow, \
     Event, Purchase, Reimbursement
 from mep.accounts.admin import SubscriptionAdminForm, BorrowAdminForm, \
     EventAdmin, EventTypeListFilter

--- a/mep/accounts/xml_models.py
+++ b/mep/accounts/xml_models.py
@@ -6,8 +6,10 @@ from eulxml import xmlmap
 from lxml.etree import cleanup_namespaces
 import pendulum
 
+
 from mep.accounts.models import Account, Subscription, SubscriptionType, \
-    Borrow, DatePrecision
+    Borrow
+from mep.accounts.partial_date import DatePrecision
 from mep.books.models import Item
 from mep.people.models import Person
 

--- a/mep/books/fixtures/oclc.rdf
+++ b/mep/books/fixtures/oclc.rdf
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+   xmlns:dcterms="http://purl.org/dc/terms/"
+   xmlns:library="http://purl.org/library/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="http://schema.org/"
+   xmlns:void="http://rdfs.org/ns/void#"
+   xmlns:wdrs="http://www.w3.org/2007/05/powder-s#"
+>
+  <rdf:Description rdf:about="http://www.worldcat.org/title/-/oclc/498910170#PublicationEvent/leiden_brill_1977">
+    <rdf:type rdf:resource="http://schema.org/PublicationEvent"/>
+    <schema:organizer rdf:resource="http://experiment.worldcat.org/entity/work/data/5090374654#Agent/brill"/>
+    <schema:startDate>1977</schema:startDate>
+    <schema:location rdf:resource="http://experiment.worldcat.org/entity/work/data/5090374654#Place/leiden"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.worldcat.org/oclc/498910170">
+    <schema:publication rdf:resource="http://www.worldcat.org/title/-/oclc/498910170#PublicationEvent/leiden_brill_1977"/>
+    <schema:isPartOf rdf:resource="http://experiment.worldcat.org/entity/work/data/5090374654#Series/etudes_preliminaires_aux_religions_orientales_dans_l_empire_romain"/>
+    <schema:productID>498910170</schema:productID>
+    <rdf:type rdf:resource="http://schema.org/Book"/>
+    <library:placeOfPublication rdf:resource="http://id.loc.gov/vocabulary/countries/ne"/>
+    <library:placeOfPublication rdf:resource="http://experiment.worldcat.org/entity/work/data/5090374654#Place/leiden"/>
+    <schema:name xml:lang="en">Apis</schema:name>
+    <rdf:type rdf:resource="http://schema.org/CreativeWork"/>
+    <schema:bookFormat rdf:resource="http://bibliograph.net/PrintBook"/>
+    <wdrs:describedby rdf:resource="http://www.worldcat.org/title/-/oclc/498910170"/>
+    <library:oclcnum>498910170</library:oclcnum>
+    <schema:inLanguage>en</schema:inLanguage>
+    <schema:publisher rdf:resource="http://experiment.worldcat.org/entity/work/data/5090374654#Agent/brill"/>
+    <schema:workExample rdf:resource="http://worldcat.org/isbn/9789004042902"/>
+    <schema:datePublished>1977</schema:datePublished>
+    <schema:exampleOfWork rdf:resource="http://worldcat.org/entity/work/id/5090374654"/>
+    <schema:workExample rdf:resource="http://worldcat.org/isbn/9789004047792"/>
+    <schema:contributor rdf:resource="http://viaf.org/viaf/84351259"/>
+    <schema:creator rdf:resource="http://viaf.org/viaf/3737014"/>
+    <schema:about rdf:resource="http://experiment.worldcat.org/entity/work/data/5090374654#Thing/ancient_egyptian_religion"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://worldcat.org/isbn/9789004042902">
+    <schema:isbn>9789004042902</schema:isbn>
+    <rdf:type rdf:resource="http://schema.org/ProductModel"/>
+    <schema:isbn>9004042903</schema:isbn>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.worldcat.org/title/-/oclc/498910170">
+    <schema:about rdf:resource="http://www.worldcat.org/oclc/498910170"/>
+    <rdf:type rdf:resource="http://www.w3.org/2006/gen/ont#InformationResource"/>
+    <rdf:type rdf:resource="http://www.w3.org/2006/gen/ont#ContentTypeGenericResource"/>
+    <schema:dateModified>2019-02-04</schema:dateModified>
+    <void:inDataset rdf:resource="http://purl.oclc.org/dataset/WorldCat"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://viaf.org/viaf/3737014">
+    <schema:name>G. J. F. Kater-Sibbes</schema:name>
+    <rdf:type rdf:resource="http://schema.org/Person"/>
+    <schema:familyName>Kater-Sibbes</schema:familyName>
+    <schema:givenName>G. J. F.</schema:givenName>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://experiment.worldcat.org/entity/work/data/5090374654#Thing/ancient_egyptian_religion">
+    <schema:name>Ancient Egyptian religion</schema:name>
+    <rdf:type rdf:resource="http://schema.org/Thing"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://viaf.org/viaf/84351259">
+    <schema:familyName>Vermaseren</schema:familyName>
+    <rdf:type rdf:resource="http://schema.org/Person"/>
+    <schema:name>Maarten Jozef Vermaseren</schema:name>
+    <schema:givenName>Maarten Jozef</schema:givenName>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://experiment.worldcat.org/entity/work/data/5090374654#Place/leiden">
+    <rdf:type rdf:resource="http://schema.org/Place"/>
+    <schema:name>Leiden</schema:name>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://worldcat.org/isbn/9789004047792">
+    <schema:isbn>9004047794</schema:isbn>
+    <rdf:type rdf:resource="http://schema.org/ProductModel"/>
+    <schema:isbn>9789004047792</schema:isbn>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://experiment.worldcat.org/entity/work/data/5090374654#Agent/brill">
+    <rdf:type rdf:resource="http://bibliograph.net/Agent"/>
+    <schema:name>Brill</schema:name>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://id.loc.gov/vocabulary/countries/ne">
+    <dcterms:identifier>ne</dcterms:identifier>
+    <rdf:type rdf:resource="http://schema.org/Place"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://experiment.worldcat.org/entity/work/data/5090374654#Series/etudes_preliminaires_aux_religions_orientales_dans_l_empire_romain">
+    <schema:hasPart rdf:resource="http://www.worldcat.org/oclc/498910170"/>
+    <rdf:type rdf:resource="http://bibliograph.net/PublicationSeries"/>
+    <schema:name>Études préliminaires aux religions orientales dans L'Empire Romain ;</schema:name>
+  </rdf:Description>
+</rdf:RDF>

--- a/mep/books/fixtures/oclc_srw_response.xml
+++ b/mep/books/fixtures/oclc_srw_response.xml
@@ -1,0 +1,583 @@
+<searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/" xmlns:oclcterms="http://purl.org/oclc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:diag="http://www.loc.gov/zing/srw/diagnostic/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<!-- demo response created from https://platform.worldcat.org/api-explorer/apis/wcapi/Bib/SRU -->
+<version>1.1</version>
+<numberOfRecords>34154</numberOfRecords>
+<records>
+<record>
+<recordSchema>marcxml</recordSchema>
+<recordPacking>xml</recordPacking>
+<recordData>
+<record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>00000cam a2200000Mi 4500</leader>
+    <controlfield tag="001">498910170</controlfield>
+    <controlfield tag="008">781214s1977    ne abf   b    001 0 eng d</controlfield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9004047794</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9789004047792</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9004042903</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9789004042902</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Kater-Sibbes, G. J. F.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">Apis /</subfield>
+      <subfield code="c">G.J.F. Kater-Sibbes and M.J. Vermaseren. 3, Inscriptions, coins and addenda.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">Leiden :</subfield>
+      <subfield code="b">Brill,</subfield>
+      <subfield code="c">1977.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">xii, 53, [3] leaves of plates (2 folded), xxviii pages of plates :</subfield>
+      <subfield code="b">illustrations (including 1 color), 2 maps ;</subfield>
+      <subfield code="c">25 cm.</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="490">
+      <subfield code="a">Études préliminaires aux religions orientales dans L'Empire Romain ;</subfield>
+      <subfield code="v">t. 48</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Vermaseren, Maarten Jozef.</subfield>
+    </datafield>
+  </record>
+</recordData>
+</record>
+<record>
+<recordSchema>marcxml</recordSchema>
+<recordPacking>xml</recordPacking>
+<recordData>
+<record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>00000cam a2200000Mi 4500</leader>
+    <controlfield tag="001">797553597</controlfield>
+    <controlfield tag="008">911015m19751977ne a   e      000 0 eng d</controlfield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9004042903</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9789004042902</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Kater-Sibbes, G. J. F.</subfield>
+      <subfield code="4">aut</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">Apis /</subfield>
+      <subfield code="c">G.J.F. Kater-Sibbes and M.J. Vermaseren.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">Leiden :</subfield>
+      <subfield code="b">Brill,</subfield>
+      <subfield code="c">1975-1977.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">3 v. :</subfield>
+      <subfield code="b">ill. ;</subfield>
+      <subfield code="c">25 cm.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="490">
+      <subfield code="a">Études préliminaires aux religions orientales dans l'empire romain ;</subfield>
+      <subfield code="v">48</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="505">
+      <subfield code="a">3 : Inscriptions, coins and addenda / with a frontespiece, 28 plates and 2 maps. -- 1977. -- XII, 53 p. -- ISBN 90-04-04779-4.</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="505">
+      <subfield code="a">1 : The monuments of the hellenistic-roman period from Egypt / with a frontespiece, 4 figures, 134 plates and 2 maps. -- 1975. -- L, 65 p. -- Bibliogr.: p. [XIII]-L. -- ISBN 90-04-04291-1.</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="505">
+      <subfield code="a">2 : Monuments from outside Egypt / with a frontespiece, 11 figures, 211 plates and 1 map. -- 1975. -- [IX], 107 p. -- ISBN 90-04-04293-8.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="4" tag="650">
+      <subfield code="a">Api (Divinità) nell'arte antica.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Apis (Egyptian deity)</subfield>
+      <subfield code="x">Art.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Idols and images</subfield>
+      <subfield code="z">Rome.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Gods, Egyptian, in art.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="651">
+      <subfield code="a">Rome</subfield>
+      <subfield code="x">Civilization</subfield>
+      <subfield code="x">Egyptian influences.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="651">
+      <subfield code="a">Rome</subfield>
+      <subfield code="x">Religious life and customs.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Vermaseren, Maarten Jozef.</subfield>
+      <subfield code="4">aut</subfield>
+    </datafield>
+  </record>
+</recordData>
+</record>
+<record>
+<recordSchema>marcxml</recordSchema>
+<recordPacking>xml</recordPacking>
+<recordData>
+<record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>00000cam a2200000Mc 4500</leader>
+    <controlfield tag="001">1072447524</controlfield>
+    <controlfield tag="008">060512s1977    ne ab         000 0 eng d</controlfield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9004047794</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9789004047792</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Kater-Sibbes, G. J. F.</subfield>
+      <subfield code="e">Verfasser</subfield>
+      <subfield code="0">(DE-588)158745027</subfield>
+      <subfield code="4">aut</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">Apis</subfield>
+      <subfield code="n">3</subfield>
+      <subfield code="p">Inscriptions, coins and addenda</subfield>
+      <subfield code="c">G. J. F. Kater-Sibbes and M. J. Vermaseren.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">Leiden</subfield>
+      <subfield code="b">Brill</subfield>
+      <subfield code="c">1977</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">getr. Zählung</subfield>
+      <subfield code="b">Ill. (z.T. farb.), Kt.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="490">
+      <subfield code="a">Études préliminaires aux religions orientales dans l'empire romain</subfield>
+      <subfield code="v">48</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Vermaseren, Maarten J.</subfield>
+      <subfield code="e">Verfasser</subfield>
+      <subfield code="0">(DE-588)177839643</subfield>
+      <subfield code="4">aut</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="8" tag="773">
+      <subfield code="w">(DE-605)HT001420186</subfield>
+      <subfield code="g">3</subfield>
+    </datafield>
+  </record>
+</recordData>
+</record>
+<record>
+<recordSchema>marcxml</recordSchema>
+<recordPacking>xml</recordPacking>
+<recordData>
+<record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>00000cam a2200000Mi 4500</leader>
+    <controlfield tag="001">924935958</controlfield>
+    <controlfield tag="008">151002s1975    ne a          001 0 eng d</controlfield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9004042903</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9789004042902</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9004042938</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9789004042933</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Kater-Sibbes, G. J. F.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">Apis.</subfield>
+      <subfield code="n">2,</subfield>
+      <subfield code="p">Monuments from outside Egypt /</subfield>
+      <subfield code="c">G. J. F. Kater-Sibbes and M. J. Vermaseren.</subfield>
+    </datafield>
+    <datafield ind1="3" ind2="0" tag="246">
+      <subfield code="a">Monuments from outside Egypt</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">Leiden :</subfield>
+      <subfield code="b">E. J. Brill,</subfield>
+      <subfield code="c">1975.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">IX, 107 s., [1] k. tabl., 211 s. tabl., [1] k. tabl. złoż. :</subfield>
+      <subfield code="b">il. ;</subfield>
+      <subfield code="c">25 cm.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="490">
+      <subfield code="a">Etudes Préliminaires aux Religions Orientales dans l'Empire Romain ;</subfield>
+      <subfield code="v">t. 48</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">Na s. tyt.: With a frontspiece, 11 figures, 211 plates and 1 map.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Vermaseren, Maarten Jozef</subfield>
+      <subfield code="d">(1918-1985).</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="710">
+      <subfield code="a">E. J. Brill (Lejda).</subfield>
+      <subfield code="4">pbl</subfield>
+    </datafield>
+  </record>
+</recordData>
+</record>
+<record>
+<recordSchema>marcxml</recordSchema>
+<recordPacking>xml</recordPacking>
+<recordData>
+<record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>00000cam a2200000Ma 4500</leader>
+    <controlfield tag="001">804336333</controlfield>
+    <controlfield tag="008">090305s2009    mau      b    001 0 eng d</controlfield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9780123743428</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">0123743427</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Thompson, Timothy J.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">Bluetooth application programming with the Java APIs :</subfield>
+      <subfield code="b">essentials edition /</subfield>
+      <subfield code="c">Timothy J. Thompson, Paul J. Kline, C. Bala Kumar.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">Burlington, MA :</subfield>
+      <subfield code="b">Morgan Kaufmann Pub.,</subfield>
+      <subfield code="c">©2008.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">XVIII, 286 p. ;</subfield>
+      <subfield code="c">23 cm</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="4" tag="650">
+      <subfield code="a">Tecnologia Bluetooth.</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="4" tag="650">
+      <subfield code="a">Interfícies de programació d'aplicacions (Programes d'ordinador)</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="4" tag="650">
+      <subfield code="a">Comunicacions sense fils, Sistemes de.</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="7" tag="650">
+      <subfield code="a">Java (Llenguatge de programació)</subfield>
+      <subfield code="2">lemac</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Kline, Paul J.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Kumar, C. Bala.</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="710">
+      <subfield code="a">Motorola Semiconductor Products Sector.</subfield>
+    </datafield>
+  </record>
+</recordData>
+</record>
+<record>
+<recordSchema>marcxml</recordSchema>
+<recordPacking>xml</recordPacking>
+<recordData>
+<record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>00000cam a2200000Mc 4500</leader>
+    <controlfield tag="001">796090842</controlfield>
+    <controlfield tag="008">140322s2012    xx            000 0 eng d</controlfield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9781449308926</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">1449308929</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Jacobson, Daniel</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">APIs :</subfield>
+      <subfield code="b">a strategy guide</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">Sebastopol :</subfield>
+      <subfield code="b">O'Reilly,</subfield>
+      <subfield code="c">2012</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">134 s</subfield>
+    </datafield>
+    <datafield ind1="8" ind2=" " tag="520">
+      <subfield code="a">Many of the highest traffic sites get more than half of their traffic not through the browser but through the APIs they have created. Salesforce.com (more than 50%) and Twitter (more than 75% fall into this category. Ebay gets more than 8 billion API calls a month. Facebook and Google, have dozens of APIs that enable both free services and e-commerce, get more than 5 billion API calls each day. Other companies like NetFlix have expanded their service of streaming movies over the the web to dozens of devices using API. At peak times, more than 20 percent of all traffic is accounted for by Netflix through its APIs. Companies like Sears and E-Trade are opening up their catalogs and other services to allow developers and entrepreneurs to create new marketing experiences. Making an API work to create a new channel is not just a matter of technology. An API must be considered in terms of business strategy, marketing, and operations as well as the technical aspects of programming. This book, written by Greg Brail, CTO of Apigee, and Brian Mulloy, VP of Products, captures the knowledge of all these areas gained by Apigee, the leading company in supporting the rollout of high traffic APIs</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Application program interfaces (Computer software)</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="4" tag="650">
+      <subfield code="a">Softwareudvikling</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Application program interfaces (Computer software)</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst00811704</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Brail, Greg</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Woods, Dan</subfield>
+    </datafield>
+  </record>
+</recordData>
+</record>
+<record>
+<recordSchema>marcxml</recordSchema>
+<recordPacking>xml</recordPacking>
+<recordData>
+<record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>00000cam a2200000Ia 4500</leader>
+    <controlfield tag="001">144220970</controlfield>
+    <controlfield tag="008">070117s2007    txua          001 0 eng d</controlfield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">1583470697</subfield>
+      <subfield code="q">(pbk.)</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9781583470695</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Vining, Bruce.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">APIs at work /</subfield>
+      <subfield code="c">Bruce Vining, Doug Pence, and Ron Hawkins.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="4" tag="246">
+      <subfield code="a">IBM system i APIs at work</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">Lewisville, TX :</subfield>
+      <subfield code="b">Mc Press,</subfield>
+      <subfield code="c">2007.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">xv, 741 pages :</subfield>
+      <subfield code="b">illustrations ;</subfield>
+      <subfield code="c">23 cm</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">Includes index.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Application program interfaces (Computer software)</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">IBM computers</subfield>
+      <subfield code="x">Programming.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Computer systems.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Application program interfaces (Computer software)</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst00811704</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">Computer systems.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst00872651</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="650">
+      <subfield code="a">IBM computers</subfield>
+      <subfield code="x">Programming.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst00966305</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Pence, Doug.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Hawkins, Ron.</subfield>
+    </datafield>
+  </record>
+</recordData>
+</record>
+<record>
+<recordSchema>marcxml</recordSchema>
+<recordPacking>xml</recordPacking>
+<recordData>
+<record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>00000cas a22000007a 4500</leader>
+    <controlfield tag="001">165151816</controlfield>
+    <controlfield tag="008">070817c20079999azuer pso     0   a0eng c</controlfield>
+    <datafield ind1=" " ind2=" " tag="010">
+      <subfield code="a">  2007212630</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="022">
+      <subfield code="a">1937-5506</subfield>
+      <subfield code="l">1937-5506</subfield>
+      <subfield code="2">1</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="130">
+      <subfield code="a">Apis (Phoenix, Az.)</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="222">
+      <subfield code="a">Apis</subfield>
+      <subfield code="b">(Phoenix, Az.)</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">Apis.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">Phoenix, AZ :</subfield>
+      <subfield code="b">CITA International Inc.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="538">
+      <subfield code="a">Mode of access: World Wide Web.</subfield>
+    </datafield>
+    <datafield ind1="4" ind2="0" tag="856">
+      <subfield code="u">http://www.knowledge21.org/apis.html</subfield>
+    </datafield>
+  </record>
+</recordData>
+</record>
+<record>
+<recordSchema>marcxml</recordSchema>
+<recordPacking>xml</recordPacking>
+<recordData>
+<record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>00000cam a2200000Mi 4500</leader>
+    <controlfield tag="001">462767731</controlfield>
+    <controlfield tag="008">790101s1975    ne a          000 0 eng d</controlfield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9004042938</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">9789004042933</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Kater-Sibbes, G. J. F.</subfield>
+      <subfield code="4">aut</subfield>
+      <subfield code="0">(FrPBN)12750262</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">Apis ...</subfield>
+      <subfield code="n">2,</subfield>
+      <subfield code="p">Monuments from outside Egypt ... _ 107 p /</subfield>
+      <subfield code="c">G.J.F. Kater-Sibbes and M.J. Vermaseren.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">Leiden :</subfield>
+      <subfield code="b">E.J. Brill ;</subfield>
+      <subfield code="a">CCXI p. de pl,</subfield>
+      <subfield code="c">1975-</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">1 dépl. :</subfield>
+      <subfield code="b">ill. en noir et en coul ;</subfield>
+      <subfield code="c">24 cm.</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="490">
+      <subfield code="a">Etudes préliminaires aux religions orientales dans l'empire romain ;</subfield>
+      <subfield code="v">48</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Vermaseren, Maarten Jozef.</subfield>
+      <subfield code="4">aut</subfield>
+      <subfield code="0">(FrPBN)12019293</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="8" tag="773">
+      <subfield code="t">Apis ...</subfield>
+      <subfield code="g">2</subfield>
+      <subfield code="w">(FrPBN)34329734</subfield>
+    </datafield>
+    <datafield ind1="4" ind2="2" tag="856">
+      <subfield code="3">Notice et cote du catalogue de la Bibliothèque nationale de France</subfield>
+      <subfield code="u">http://catalogue.bnf.fr/ark:/12148/cb35371092r</subfield>
+    </datafield>
+  </record>
+</recordData>
+</record>
+<record>
+<recordSchema>marcxml</recordSchema>
+<recordPacking>xml</recordPacking>
+<recordData>
+<record xmlns="http://www.loc.gov/MARC21/slim">
+    <leader>00000cam a2200000Ma 4500</leader>
+    <controlfield tag="001">911727061</controlfield>
+    <controlfield tag="008">930205s1975    xx            000 0 eng d</controlfield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Kater-Sibbes, G. J. F.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">Apis .</subfield>
+      <subfield code="n">Vol. 1,</subfield>
+      <subfield code="p">The monuments of the Hellenistic-Roman period from Egypt.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="c">Leiden :</subfield>
+      <subfield code="b">E.J. Brill,</subfield>
+      <subfield code="c">1975.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">65 p., CXXXIV p. de lám. ;</subfield>
+      <subfield code="c">25 cm.</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="490">
+      <subfield code="a">Etudes préliminaires aux religions orientales dans l'empire romain ;</subfield>
+      <subfield code="v">48</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="4" tag="650">
+      <subfield code="a">Apis (Personaje mitológico) en el arte.</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="4" tag="650">
+      <subfield code="a">Mitología romana</subfield>
+      <subfield code="x">Influencia oriental.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="4" tag="651">
+      <subfield code="a">Religión egipcia.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="4" tag="651">
+      <subfield code="a">Religión romana.</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="7" tag="650">
+      <subfield code="a">Apis (Personaje mitológico)</subfield>
+      <subfield code="x">Iconografía.</subfield>
+      <subfield code="2">embucm</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="700">
+      <subfield code="a">Vermaseren, M. J.</subfield>
+      <subfield code="q">(Maarten Jozef)</subfield>
+    </datafield>
+  </record>
+</recordData>
+</record>
+</records>
+<nextRecordPosition>11</nextRecordPosition>
+<resultSetIdleTime/>
+<echoedSearchRetrieveRequest xmlns:srw="http://www.loc.gov/zing/srw/">
+<version>1.1</version>
+<query>srw.kw all "APIs"</query>
+<maximumRecords>10</maximumRecords>
+<recordPacking>xml</recordPacking>
+<startRecord>1</startRecord>
+<sortKeys>relevance</sortKeys>
+<wskey>{built-in-api-key}</wskey>
+</echoedSearchRetrieveRequest>
+</searchRetrieveResponse>

--- a/mep/books/management/commands/reconcile_oclc.py
+++ b/mep/books/management/commands/reconcile_oclc.py
@@ -1,0 +1,90 @@
+import codecs
+import csv
+from typing import Dict
+
+from django.core.management.base import BaseCommand
+import pymarc
+
+from mep.books.models import Item
+from mep.books.oclc import SRUSearch, oclc_uri, get_work_uri
+
+
+class Command(BaseCommand):
+    """Associate library items with OCLC entries via WordCat Search API"""
+    help = __doc__
+
+    sru_search = None
+
+    #: fields to be included in CSV export
+    csv_fieldnames = [
+        # details from local db
+        'Title', 'Date', 'Creators',
+        # details from OCLC
+        'OCLC Title', 'OCLC Author', 'OCLC Date', 'OCLC URI',
+        'Work URI', '# matches',
+        # db notes last
+        'Notes']
+
+    def handle(self, *args, **kwargs):
+        """Loop through Items in the database and look for matches in OCLC"""
+        self.sru_search = SRUSearch()
+
+        # filter out items with problems that we don't expect to be
+        # able to match reliably
+        items = Item.objects.exclude(notes__contains='GENERIC') \
+                            .exclude(notes__contains='PROBLEM') \
+                            .exclude(notes__contains='OBSCURE') \
+                            .exclude(title__endswith='*')
+
+        with open('items-oclc.csv', 'w') as csvfile:
+            # write utf-8 byte order mark at the beginning of the file
+            csvfile.write(codecs.BOM_UTF8.decode())
+
+            writer = csv.DictWriter(csvfile, fieldnames=self.csv_fieldnames)
+            writer.writeheader()
+
+            for item in items:
+                info = {
+                    'Title': item.title,
+                    'Date': item.year,
+                    'Creators': ';'.join([str(person) for person in item.creators.all()]),
+                    'Notes': item.notes
+                }
+                info.update(self.oclc_search(item))
+                writer.writerow(info)
+
+    def oclc_search(self, item: Item) -> Dict:
+        """Search for an item in OCLC by title, author, date.
+        Returns dictionary with details found for inclusion in CSV.
+        """
+        # get local instance of sru_search to add filters to
+        sru_search = self.sru_search.filter()
+
+        if item.title:
+            sru_search = sru_search.filter(title__exact='"%s"' % item.title)
+
+        if item.authors.exists():
+            sru_search = sru_search.filter(author__all='"%s"' % item.authors.first())
+
+        if item.year:
+            sru_search = sru_search.filter(year=item.year)
+        else:
+            first_date = item.first_known_interaction
+            if first_date:
+                # range search ending with first known event date
+                sru_search = sru_search.filter(year="-%s" % first_date.year)
+
+        result = sru_search.search()
+        # report number of matches so 0 is explicit/obvious
+        oclc_info = {'# matches': result.num_records}
+        if result.num_records:
+            # assume first record is best match (seems to be true)
+            marc_record = result.marc_records[0]
+            oclc_info.update({
+                'OCLC Title': marc_record.title(),
+                'OCLC Author': marc_record.author(),
+                'OCLC Date': marc_record.pubyear(),
+                'OCLC URI': oclc_uri(marc_record),
+                'Work URI': get_work_uri(marc_record)
+            })
+        return oclc_info

--- a/mep/books/models.py
+++ b/mep/books/models.py
@@ -135,11 +135,15 @@ class Item(Notable, Indexable):
     @property
     def first_known_interaction(self) -> datetime.date:
         '''date of the earliest known interaction for this item'''
+
+        # search for the earliest start date, excluding any borrow
+        # or purchase events with unknown years
         first_event = self.event_set \
             .filter(start_date__isnull=False) \
+            .exclude(borrow__start_date_precision__knownyear=False) \
+            .exclude(purchase__start_date_precision__knownyear=False) \
             .order_by('start_date').first()
 
-        # TODO: does not currently filter out dates with unknown years
         if first_event:
             return first_event.start_date
 

--- a/mep/books/models.py
+++ b/mep/books/models.py
@@ -1,6 +1,7 @@
+import datetime
+
 from django.db import models
 from django.urls import reverse
-
 from parasolr.indexing import Indexable
 
 from mep.common.models import Named, Notable
@@ -131,12 +132,22 @@ class Item(Notable, Indexable):
 
         return index_data
 
+    @property
+    def first_known_interaction(self) -> datetime.date:
+        '''date of the earliest known interaction for this item'''
+        first_event = self.event_set \
+            .filter(start_date__isnull=False) \
+            .order_by('start_date').first()
+
+        # TODO: does not currently filter out dates with unknown years
+        if first_event:
+            return first_event.start_date
+
 
 class CreatorType(Named, Notable):
     '''Type of creator role a person can have to an item; author,
     editor, translator, etc.'''
     pass
-
 
 class Creator(Notable):
     creator_type = models.ForeignKey(CreatorType)

--- a/mep/books/oclc.py
+++ b/mep/books/oclc.py
@@ -1,0 +1,93 @@
+'''
+Module for collecting OCLC search functionality, particularly SRU style
+searches.
+'''
+from io import BytesIO
+from logging import getLogger
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from eulxml import xmlmap
+import pymarc
+import requests
+
+logger = getLogger(__name__)
+
+
+class WorldCatClientBase:
+    '''Mixin base for clients interacting with the Worldcat API.'''
+
+    WORLDCAT_API_BASE = 'http://www.worldcat.org/webservices/catalog'
+    API_ENDPOINT = ''
+
+    def __init__(self):
+
+        # Get WSKey or error if not specified
+        wskey = getattr(settings, 'OCLC_WSKEY', None)
+        if not wskey:
+            raise ImproperlyConfigured('OCLC search functionality '
+                                       'requires a WSKEY.')
+        # Configure a session to use WS_KEY
+        self.session = requests.Session()
+        self.session.params.update({
+            'wskey': wskey
+        })
+        # initialize an empty query
+        self.query = []
+
+    @property
+    def query_string(self):
+        """Return an AND formatting query string."""
+        return ' AND '.join(self.query)
+
+
+    def search(self, **kwargs):
+        '''Extendable method to process the results of a search query'''
+        kwargs.update({'query': self.query_string})
+        try:
+            response = self.session.get(
+                ('%s/%s' % (self.WORLDCAT_API_BASE,
+                            self.API_ENDPOINT)).strip('/'),
+                params=kwargs)
+            if response.status_code == requests.codes.OK:
+                print('foo')
+                return response
+        except requests.RequestException as err:
+            logger.exception(err)
+
+
+class SrwResponse(xmlmap.XmlObject):
+    '''Object to parse SRW formatted responses.'''
+    ROOT_NAMESPACES = {
+        'srw': 'http://www.loc.gov/zing/srw/'
+    }
+
+    num_records = xmlmap.IntegerField('srw:numberOfRecords')
+
+
+class SruSearch(WorldCatClientBase):
+    '''Client for peforming an SRU (specific edition) based search'''
+
+    API_ENDPOINT = 'search/worldcat/sru'
+
+    def __init__(self):
+        super().__init__()
+        self.num_records = 0
+
+    def filter(self, filter_string):
+        '''Add another filter to the :class:`SRUSearch` object and return
+        self to allow chaining.'''
+        self.query.append(filter_string)
+        return self
+
+    def search(self, **kwargs):
+        '''Perform a CQL based search based on chained filters.'''
+        response = super().search(**kwargs)
+        if response:
+            # set the number of records for use in pulling max count
+            srw_response = xmlmap\
+                .load_xmlobject_from_string(response.text, SrwResponse)
+            if srw_response.is_valid():
+                self.num_records = srw_response.num_records
+        return pymarc.parse_xml_to_array(BytesIO(response.content))
+

--- a/mep/books/oclc.py
+++ b/mep/books/oclc.py
@@ -2,14 +2,16 @@
 Module for collecting OCLC search functionality, particularly SRU style
 searches.
 '''
-from io import BytesIO
+from io import BytesIO, StringIO
 from logging import getLogger
+import time
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from eulxml import xmlmap
 import pymarc
 import requests
+
 
 logger = getLogger(__name__)
 
@@ -29,6 +31,7 @@ class WorldCatClientBase:
                                        'requires a WSKEY.')
         # Configure a session to use WS_KEY
         self.session = requests.Session()
+        # should we set a contact header?
         self.session.params.update({
             'wskey': wskey
         })
@@ -40,53 +43,100 @@ class WorldCatClientBase:
         """Return an AND formatting query string."""
         return ' AND '.join(self.query)
 
-
     def search(self, **kwargs):
         '''Extendable method to process the results of a search query'''
         kwargs.update({'query': self.query_string})
+        start = time.time()
         try:
             response = self.session.get(
                 ('%s/%s' % (self.WORLDCAT_API_BASE,
                             self.API_ENDPOINT)).strip('/'),
                 params=kwargs)
-            if response.status_code == requests.codes.OK:
+            # log the url call and response time
+            logger.debug('search %s => %d: %f sec',
+                         self.query_string, response.status_code,
+                         time.time() - start)
+            if response.status_code == requests.codes.ok:
                 return response
         except requests.exceptions.ConnectionError as err:
             logger.exception(err)
 
 
-class SrwResponse(xmlmap.XmlObject):
+class SRWResponse(xmlmap.XmlObject):
     '''Object to parse SRW formatted responses.'''
     ROOT_NAMESPACES = {
         'srw': 'http://www.loc.gov/zing/srw/'
     }
 
+    #: number of records found for the query
     num_records = xmlmap.IntegerField('srw:numberOfRecords')
+    #: returned records as :class:`~eulxml.xmlmap.XmlObject`
+    records = xmlmap.NodeField('srw:records', xmlmap.XmlObject)
+
+    @property
+    def marc_records(self):
+        # serialize xml to a bytebytestream for loading by pymarc
+        bytestream = BytesIO()
+        self.serializeDocument(bytestream)
+        bytestream.seek(0)
+        # pymarc is returning 'None' in the array alternating with
+        # pymarc records; not sure why, but filter them out
+        return list(filter(None, pymarc.parse_xml_to_array(bytestream)))
 
 
-class SruSearch(WorldCatClientBase):
+class SRUSearch(WorldCatClientBase):
     '''Client for peforming an SRU (specific edition) based search'''
 
     API_ENDPOINT = 'search/worldcat/sru'
 
     def __init__(self):
         super().__init__()
-        self.num_records = 0
 
-    def filter(self, filter_string):
+    # mapping of field lookup to srw field abbreviation
+    search_fields = {
+        'title': 'ti',
+        'author': 'au',
+        'year': 'yr',
+        'keyword': 'kw'
+    }
+
+    def filter(self, *args, **kwargs):
         '''Add another filter to the :class:`SRUSearch` object and return
         self to allow chaining.'''
-        self.query.append(filter_string)
-        return self
+        search_copy = self._clone()
+        search_copy.query.extend(args)
+        for key, val in kwargs.items():
+            # split field on __ to allow for specifying operator
+            field_parts = key.split('__', 1)
+            field = field_parts[0]
+
+            # convert readable field names to srw field via lookup
+            if field in self.search_fields:
+                field = 'srw.%s' % self.search_fields[field]
+
+            if len(field_parts) > 1:
+                # spaces needed for everything besides = (?)
+                operator = ' %s ' % field_parts[1]
+            else:
+                # assume equal if not specified
+                operator = '='
+
+            # *maybe* could infer when to wrap quotes around val
+            # based on type (e.g. str vs numeric)
+
+            search_copy.query.append('%s%s%s' % (field, operator, val))
+
+        return search_copy
+
+    def _clone(self):
+        search_copy = self.__class__()
+        search_copy.query = list(self.query)
+        return search_copy
 
     def search(self, **kwargs):
         '''Perform a CQL based search based on chained filters.'''
         response = super().search(**kwargs)
         if response:
-            # set the number of records for use in pulling max count
-            srw_response = xmlmap\
-                .load_xmlobject_from_string(response.text, SrwResponse)
-            if srw_response.is_valid():
-                self.num_records = srw_response.num_records
-        return pymarc.parse_xml_to_array(BytesIO(response.content))
-
+            # parse and return as SRW Response
+            return xmlmap.load_xmlobject_from_string(
+                response.content, SRWResponse)

--- a/mep/books/oclc.py
+++ b/mep/books/oclc.py
@@ -50,9 +50,8 @@ class WorldCatClientBase:
                             self.API_ENDPOINT)).strip('/'),
                 params=kwargs)
             if response.status_code == requests.codes.OK:
-                print('foo')
                 return response
-        except requests.RequestException as err:
+        except requests.exceptions.ConnectionError as err:
             logger.exception(err)
 
 

--- a/mep/books/tests/test_books_commands.py
+++ b/mep/books/tests/test_books_commands.py
@@ -6,6 +6,7 @@ from tempfile import NamedTemporaryFile
 from unittest.mock import patch, Mock
 
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.core.management import call_command
 import pymarc
 
@@ -16,12 +17,14 @@ from mep.people.models import Person
 from mep.books.tests.test_oclc import get_srwresponse_xml_fixture
 
 
+
 class TestReconcileOCLC(TestCase):
 
     def setUp(self):
         self.cmd = reconcile_oclc.Command()
         self.cmd.stdout = StringIO()
 
+    @override_settings(OCLC_WSKEY='secretkey')
     @patch('mep.books.management.commands.reconcile_oclc.progressbar')
     @patch.object(reconcile_oclc.Command, 'oclc_search')
     def test_command_line(self, mock_oclc_search, mockprogressbar):

--- a/mep/books/tests/test_books_commands.py
+++ b/mep/books/tests/test_books_commands.py
@@ -1,0 +1,143 @@
+import codecs
+import datetime
+from io import StringIO
+import os
+from tempfile import NamedTemporaryFile
+from unittest.mock import patch, Mock
+
+from django.test import TestCase
+from django.core.management import call_command
+import pymarc
+
+from mep.books.management.commands import reconcile_oclc
+from mep.books.models import Item, CreatorType, Creator
+from mep.books.oclc import oclc_uri
+from mep.people.models import Person
+from mep.books.tests.test_oclc import get_srwresponse_xml_fixture
+
+
+class TestReconcileOCLC(TestCase):
+
+    def setUp(self):
+        self.cmd = reconcile_oclc.Command()
+        self.cmd.stdout = StringIO()
+
+    @patch('mep.books.management.commands.reconcile_oclc.progressbar')
+    @patch.object(reconcile_oclc.Command, 'oclc_search')
+    def test_command_line(self, mock_oclc_search, mockprogressbar):
+        # test calling via command line with args
+        csvtempfile = NamedTemporaryFile(suffix='csv')
+        stdout = StringIO()
+        call_command('reconcile_oclc', '-o', csvtempfile.name, stdout=stdout)
+        output = stdout.getvalue()
+        assert '0 items to reconcile' in output
+        # no file output
+        assert not os.stat(csvtempfile.name).st_size
+        # no progbar
+        mockprogressbar.ProgressBar.assert_not_called()
+
+        # create items that should be ignored (generic, problem, title*)
+        Item.objects.create(notes="GENERIC can't identify")
+        Item.objects.create(notes="PROBLEM some problematic issue here")
+        Item.objects.create(notes="OBSCURE")
+        Item.objects.create(title="Plays*")
+        stdout = StringIO()
+        call_command('reconcile_oclc', '-o', csvtempfile.name, stdout=stdout)
+        output = stdout.getvalue()
+        assert '0 items to reconcile' in output
+        # no file output
+        assert not os.stat(csvtempfile.name).st_size
+        # no progbar
+        mockprogressbar.ProgressBar.assert_not_called()
+
+        # create items that should be processed
+        item1 = Item.objects.create(title="Patriotic Adventurer", year=1936)
+        # with one author to sanity-check included in output
+        ctype = CreatorType.objects.get(name='Author')
+        person = Person.objects.create(sort_name='Ireland, Denis')
+        Creator.objects.create(creator_type=ctype, person=person, item=item1)
+        item2 = Item.objects.create(title="Crowded House", notes="Variant title")
+        stdout = StringIO()
+        call_command('reconcile_oclc', '-o', csvtempfile.name, stdout=stdout)
+        output = stdout.getvalue()
+        assert '2 items to reconcile' in output
+        # search should be called once for each non-skipped item
+        assert mock_oclc_search.call_count == 2
+
+        # check csvfile contents
+        csvtempfile.seek(0)
+        csv_content = csvtempfile.read().decode()
+        # csv output should have byte-order marck
+        assert csv_content.startswith(codecs.BOM_UTF8.decode())
+        # csv output should have header row
+        assert ','.join(self.cmd.csv_fieldnames) in csv_content
+        # csv output should include summary book details from db
+        assert item1.title in csv_content
+        assert str(item1.year) in csv_content
+        assert str(person) in csv_content
+        assert item2.title in csv_content
+        assert item2.notes in csv_content
+
+        # no progress option respected
+        mockprogressbar.reset_mock()
+        call_command('reconcile_oclc', '-o', csvtempfile.name,
+                    '--no-progress', stdout=stdout)
+        mockprogressbar.ProgressBar.assert_not_called()
+
+    def test_oclc_search(self):
+        mock_sru_search = Mock()
+        self.cmd.sru_search = mock_sru_search
+        # use SRW response fixture for search response
+        srwresponse = get_srwresponse_xml_fixture()
+        mock_sru_search.search.return_value = srwresponse
+
+        # search item with title, author, year
+        item = Item.objects.create(title="Patriotic Adventurer", year=1936)
+        # with one author to sanity-check included in output
+        ctype = CreatorType.objects.get(name='Author')
+        person = Person.objects.create(sort_name='Ireland, Denis')
+        creator = Creator.objects.create(creator_type=ctype, person=person, item=item)
+
+        oclc_info = self.cmd.oclc_search(item)
+        # should search on title, author, year
+        mock_sru_search.search.assert_called_with(
+            title__exact=item.title, author__all=str(person),
+            year=item.year)
+        # uses first marc record in the response
+        marc_record = srwresponse.marc_records[0]
+        # can't use assert called with because marc record objects
+        # are different, since they are generated dynamically by pymarc
+        assert mock_sru_search.get_work_uri.call_count == 1
+        args = mock_sru_search.get_work_uri.call_args[0]
+        assert isinstance(args[0], pymarc.record.Record)
+
+        # inspect returned details
+        assert oclc_info['# matches'] == srwresponse.num_records
+        assert oclc_info['OCLC Title'] == marc_record.title()
+        assert oclc_info['OCLC Author'] == marc_record.author()
+        assert oclc_info['OCLC Date'] == marc_record.pubyear()
+        assert oclc_info['OCLC URI'] == oclc_uri(marc_record)
+        assert oclc_info['Work URI'] == mock_sru_search.get_work_uri.return_value
+
+        # search does not include missing fields
+        # - delete all but title, no events for first known interaction
+        creator.delete()
+        item.year = None
+        oclc_info = self.cmd.oclc_search(item)
+        # should search on title only
+        mock_sru_search.search.assert_called_with(title__exact=item.title)
+
+        # simulate no year but first known year from events
+        with patch.object(Item, 'first_known_interaction', new=datetime.date(1940, 1, 1)):
+            oclc_info = self.cmd.oclc_search(item)
+            # should search on title and year range
+            mock_sru_search.search.assert_called_with(
+                title__exact=item.title, year="-1940")
+
+        # simulate no results found
+        srwresponse.num_records = 0
+        oclc_info = self.cmd.oclc_search(item)
+        print(oclc_info)
+        # should report 0 matches and nothing else
+        assert oclc_info['# matches'] == 0
+        assert len(oclc_info) == 1

--- a/mep/books/tests/test_books_models.py
+++ b/mep/books/tests/test_books_models.py
@@ -97,12 +97,11 @@ class TestItem(TestCase):
         assert item.first_known_interaction == borrow_date
 
         # create a borrow with an unknown date
-        # TODO, not yet implemented
-        # unknown_borrow = Borrow.objects.create(item=item, account=acct)
-        # unknown_borrow.partial_start_date = '--01-01'
-        # unknown_borrow.save()
-        # # should use previous borrow date, not the unknown (1900)
-        # assert item.first_known_interaction == borrow_date
+        unknown_borrow = Borrow.objects.create(item=item, account=acct)
+        unknown_borrow.partial_start_date = '--01-01'
+        unknown_borrow.save()
+        # should use previous borrow date, not the unknown (1900)
+        assert item.first_known_interaction == borrow_date
 
 
 class TestPublisher(TestCase):

--- a/mep/books/tests/test_books_models.py
+++ b/mep/books/tests/test_books_models.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 
 from django.test import TestCase
@@ -28,7 +29,6 @@ class TestItem(TestCase):
         assert str(item) == '(No title, year)'
 
     def test_borrow_count(self):
-
         # create a test item
         # should have zero borrows
         item = Item(title='Le foo et le bar', year=1916)
@@ -80,6 +80,29 @@ class TestItem(TestCase):
 
         assert len(item.translators) == 1
         assert item.translators.first() == translator
+
+    def test_first_known_interaction(self):
+        # create a test item with no events
+        item = Item.objects.create(title='Searching')
+        assert not item.first_known_interaction
+
+        # create a borrow with date
+        acct = Account()
+        acct.save()
+        borrow_date = datetime.date(1940, 3, 2)
+        borrow = Borrow(item=item, account=acct)
+        borrow.partial_start_date = borrow_date.isoformat()
+        borrow.save()
+        # first date should be borrow start date
+        assert item.first_known_interaction == borrow_date
+
+        # create a borrow with an unknown date
+        # TODO, not yet implemented
+        # unknown_borrow = Borrow.objects.create(item=item, account=acct)
+        # unknown_borrow.partial_start_date = '--01-01'
+        # unknown_borrow.save()
+        # # should use previous borrow date, not the unknown (1900)
+        # assert item.first_known_interaction == borrow_date
 
 
 class TestPublisher(TestCase):

--- a/mep/books/tests/test_oclc.py
+++ b/mep/books/tests/test_oclc.py
@@ -138,5 +138,5 @@ class TestSRWResponse:
         assert isinstance(marc_records[0], pymarc.record.Record)
 
         # sanity check value from first and last record
-        marc_records[0]['001'] == 498910170
-        marc_records[-1]['001'] == 911727061
+        assert marc_records[0]['001'].value() == '498910170'
+        assert marc_records[-1]['001'].value() == '911727061'

--- a/mep/books/tests/test_oclc.py
+++ b/mep/books/tests/test_oclc.py
@@ -11,7 +11,7 @@ import rdflib
 import requests
 
 from mep.books.oclc import WorldCatClientBase, SRUSearch, SRWResponse, \
-    get_work_uri
+    get_work_uri, oclc_uri
 
 
 FIXTURE_DIR = os.path.join('mep', 'books', 'fixtures')
@@ -146,6 +146,19 @@ class TestSRWResponse:
         assert marc_records[0]['001'].value() == '498910170'
         assert marc_records[-1]['001'].value() == '911727061'
 
+
+def get_test_marc_record():
+    # load sw fixture and use first marc record
+    return xmlmap.load_xmlobject_from_file(
+        SRW_RESPONSE_FIXTURE, SRWResponse).marc_records[0]
+
+
+def test_oclc_uri():
+    marc_record = get_test_marc_record()
+    assert oclc_uri(marc_record) == \
+        'http://www.worldcat.org/oclc/%s' % marc_record['001'].value()
+
+
 @patch('mep.books.oclc.rdflib', spec=True)
 def test_get_work_uri(mockrdflib):
     # load fixture as graph and set mock to return it.
@@ -158,9 +171,7 @@ def test_get_work_uri(mockrdflib):
     # use the real URIRef
     mockrdflib.URIRef = rdflib.URIRef
 
-    # load sw fixture and use first marc record
-    marc_record = xmlmap.load_xmlobject_from_file(
-        SRW_RESPONSE_FIXTURE, SRWResponse).marc_records[0]
+    marc_record = get_test_marc_record()
 
     with patch.object(test_graph, 'parse') as mockparse:
         work_uri = get_work_uri(marc_record)

--- a/mep/books/tests/test_oclc.py
+++ b/mep/books/tests/test_oclc.py
@@ -1,0 +1,79 @@
+import os
+from unittest.mock import Mock, patch
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+import pytest
+import requests
+
+from mep.books.oclc import WorldCatClientBase
+
+FIXTURES_DIR = os.path.join('mep', 'books', 'fixtures')
+
+class TestWorldCatClientBase(SimpleTestCase):
+
+    def test_init(self):
+        with self.settings(OCLC_WSKEY=''):
+            with pytest.raises(ImproperlyConfigured):
+                wc = WorldCatClientBase()
+        with self.settings(OCLC_WSKEY='secretkey'):
+            wc = WorldCatClientBase()
+            assert isinstance(wc.session, requests.Session)
+            assert wc.session.params['wskey'] == 'secretkey'
+            assert wc.query == []
+
+    @override_settings(OCLC_WSKEY='fakekey')
+    def test_query_string(self):
+        wc = WorldCatClientBase()
+        wc.query = [
+            'A',
+            'B',
+            'C'
+        ]
+        assert wc.query_string == 'A AND B AND C'
+
+    @patch('mep.books.oclc.requests')
+    @override_settings(OCLC_WSKEY='fakekey')
+    def test_search(self, mock_requests):
+        mock_requests.codes.OK = request.codes.OK
+        mock_session = mock_requests.Session.return_value
+        mock_session.get.return_value = Mock()
+        mock_session.get.return_value.status_code = 200
+        wc = WorldCatClientBase()
+        wc.query = ['foo', 'bar']
+        # successful run, status code 200
+        response = wc.search(baz='Y',bar='foo')
+        # calls get as specified, with passed in kwargs
+        mock_session.get.assert_called_with(
+            wc.WORLDCAT_API_BASE,
+            params={
+                'query': 'foo AND bar',
+                'baz': 'Y',
+                'bar': 'foo'
+            }
+        )
+        # returns the output of session.get
+        assert response == mock_session.get.return_value
+        # unsuccessful run, non-200 status code, returns None
+        mock_session.get.return_value.status_code = 401
+        response = wc.search()
+        assert response is None
+        # unsuccessful run, raises a requests exception
+        # should be handled by returning None
+        # make sure that the status_code doesn't affect this
+        mock_session.get.return_value.status_code = 200
+        mock_session.get.side_effect = requests.ConnectionError
+        response = wc.search()
+        assert response is None
+
+@patch('mep.books.oclc.WorldCatClientBase.search')
+class SrwResponse(TestCase):
+    with open(os.path.join(FIXTURES_DIR, 'sample-sru.response.xml'), 'rb') as fp:
+        xml_bytes = fp.read()
+
+    xml_string = xml_bytes.decode('utf-8')
+
+
+
+

--- a/mep/books/tests/test_oclc.py
+++ b/mep/books/tests/test_oclc.py
@@ -36,7 +36,10 @@ class TestWorldCatClientBase(SimpleTestCase):
     @patch('mep.books.oclc.requests')
     @override_settings(OCLC_WSKEY='fakekey')
     def test_search(self, mock_requests):
-        mock_requests.codes.OK = request.codes.OK
+        # stub back in codes and exceptions for requests
+        mock_requests.codes.OK = requests.codes.OK
+        mock_requests.exceptions.ConnectionError = requests.exceptions.ConnectionError
+        # mock out an object that can have a return_code to check
         mock_session = mock_requests.Session.return_value
         mock_session.get.return_value = Mock()
         mock_session.get.return_value.status_code = 200
@@ -63,6 +66,6 @@ class TestWorldCatClientBase(SimpleTestCase):
         # should be handled by returning None
         # make sure that the status_code doesn't affect this
         mock_session.get.return_value.status_code = 200
-        mock_session.get.side_effect = requests.ConnectionError
+        mock_session.get.side_effect = requests.exceptions.ConnectionError
         response = wc.search()
         assert response is None

--- a/mep/books/tests/test_oclc.py
+++ b/mep/books/tests/test_oclc.py
@@ -2,6 +2,7 @@ import os
 from unittest.mock import Mock, patch
 
 from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase
 from django.test.utils import override_settings
 from eulxml import xmlmap
 import pymarc
@@ -75,7 +76,8 @@ class TestWorldCatClientBase:
         assert not response
 
 
-class TestSRUSearch:
+@override_settings(OCLC_WSKEY='my-secret-key')
+class TestSRUSearch(SimpleTestCase):
     response_fixture = os.path.join(FIXTURES_DIR, 'oclc_srw_response.xml')
 
     def test_clone(self):

--- a/mep/books/tests/test_oclc.py
+++ b/mep/books/tests/test_oclc.py
@@ -125,6 +125,15 @@ class TestSRUSearch(SimpleTestCase):
             # returns response object
             assert isinstance(resp, SRWResponse)
 
+            # 200 response but not valid xml
+            mock_base_search.return_value.content = 'foo'
+            # use patch since can't get pytest caplog to work
+            with patch('mep.books.oclc.logger') as mock_logger:
+                assert not SRUSearch().search()
+                assert mock_logger.error.call_count == 1
+                args = mock_logger.error.call_args[0]
+                assert 'Error parsing response' in args[0]
+
             # no response - no error, no response
             mock_base_search.return_value = None
             assert not SRUSearch().search()

--- a/mep/books/tests/test_oclc.py
+++ b/mep/books/tests/test_oclc.py
@@ -2,54 +2,57 @@ import os
 from unittest.mock import Mock, patch
 
 from django.core.exceptions import ImproperlyConfigured
-from django.test import SimpleTestCase
 from django.test.utils import override_settings
+from eulxml import xmlmap
+import pymarc
 import pytest
 import requests
 
-from mep.books.oclc import WorldCatClientBase
+from mep.books.oclc import WorldCatClientBase, SRUSearch, SRWResponse
 
 FIXTURES_DIR = os.path.join('mep', 'books', 'fixtures')
 
-class TestWorldCatClientBase(SimpleTestCase):
+
+class TestWorldCatClientBase:
 
     def test_init(self):
-        with self.settings(OCLC_WSKEY=''):
+        with override_settings(OCLC_WSKEY=''):
             with pytest.raises(ImproperlyConfigured):
-                wc = WorldCatClientBase()
-        with self.settings(OCLC_WSKEY='secretkey'):
-            wc = WorldCatClientBase()
-            assert isinstance(wc.session, requests.Session)
-            assert wc.session.params['wskey'] == 'secretkey'
-            assert wc.query == []
+                WorldCatClientBase()
+
+        with override_settings(OCLC_WSKEY='secretkey'):
+            wcb = WorldCatClientBase()
+            assert isinstance(wcb.session, requests.Session)
+            assert wcb.session.params['wskey'] == 'secretkey'
+            assert wcb.query == []
 
     @override_settings(OCLC_WSKEY='fakekey')
     def test_query_string(self):
-        wc = WorldCatClientBase()
-        wc.query = [
+        wcb = WorldCatClientBase()
+        wcb.query = [
             'A',
             'B',
             'C'
         ]
-        assert wc.query_string == 'A AND B AND C'
+        assert wcb.query_string == 'A AND B AND C'
 
     @patch('mep.books.oclc.requests')
     @override_settings(OCLC_WSKEY='fakekey')
     def test_search(self, mock_requests):
         # stub back in codes and exceptions for requests
-        mock_requests.codes.OK = requests.codes.OK
+        mock_requests.codes.ok = requests.codes.ok
         mock_requests.exceptions.ConnectionError = requests.exceptions.ConnectionError
         # mock out an object that can have a return_code to check
         mock_session = mock_requests.Session.return_value
         mock_session.get.return_value = Mock()
         mock_session.get.return_value.status_code = 200
-        wc = WorldCatClientBase()
-        wc.query = ['foo', 'bar']
+        wcb = WorldCatClientBase()
+        wcb.query = ['foo', 'bar']
         # successful run, status code 200
-        response = wc.search(baz='Y',bar='foo')
+        response = wcb.search(baz='Y', bar='foo')
         # calls get as specified, with passed in kwargs
         mock_session.get.assert_called_with(
-            wc.WORLDCAT_API_BASE,
+            wcb.WORLDCAT_API_BASE,
             params={
                 'query': 'foo AND bar',
                 'baz': 'Y',
@@ -60,12 +63,80 @@ class TestWorldCatClientBase(SimpleTestCase):
         assert response == mock_session.get.return_value
         # unsuccessful run, non-200 status code, returns None
         mock_session.get.return_value.status_code = 401
-        response = wc.search()
-        assert response is None
+        response = wcb.search()
+        assert not response
+
         # unsuccessful run, raises a requests exception
         # should be handled by returning None
         # make sure that the status_code doesn't affect this
         mock_session.get.return_value.status_code = 200
         mock_session.get.side_effect = requests.exceptions.ConnectionError
-        response = wc.search()
-        assert response is None
+        response = wcb.search()
+        assert not response
+
+
+class TestSRUSearch:
+    response_fixture = os.path.join(FIXTURES_DIR, 'oclc_srw_response.xml')
+
+    def test_clone(self):
+        srus = SRUSearch()
+        srus.query = ['foo']
+        clone_srus = srus._clone()
+        # query lists should be equal but *not* the same object
+        assert clone_srus.query == srus.query
+        assert clone_srus.query is not srus.query
+
+    def test_filter(self):
+        srus = SRUSearch()
+        # list of filters as args
+        filter_args = ['srw.yr=1901', 'srw.ti exact "Ulysses"']
+        filter_srus = srus.filter(*filter_args)
+        # args added to list of queries as-is
+        assert filter_srus.query == filter_args
+        # original query untouched
+        assert not srus.query
+
+        # field=value filter with lookup
+        title_srus = srus.filter(title="Ulysses")
+        # title converted to srw.ti, equal inferred
+        assert 'srw.ti=Ulysses' in title_srus.query
+        # field__operator=value filter with operator specified
+        author_srus = srus.filter(author__any="James Joyce")
+        assert 'srw.au any James Joyce' in author_srus.query
+
+    @patch('mep.books.oclc.WorldCatClientBase.search')
+    def test_search(self, mock_base_search):
+        with open(self.response_fixture) as response:
+            # return fixture as response
+            mock_base_search.return_value.content = response.read()
+            resp = SRUSearch().search()
+            # returns response object
+            assert isinstance(resp, SRWResponse)
+
+            # no response - no error, no response
+            mock_base_search.return_value = None
+            assert not SRUSearch().search()
+
+
+class TestSRWResponse:
+
+    fixture = os.path.join(FIXTURES_DIR, 'oclc_srw_response.xml')
+
+    def get_fixture_obj(self):
+        # initialize and return SRWResponse from fixture
+        return xmlmap.load_xmlobject_from_file(
+            self.fixture, SRWResponse)
+
+    def test_fields(self):
+        srw_response = self.get_fixture_obj()
+        assert srw_response.num_records == 34154
+
+    def test_marc_records(self):
+        srw_response = self.get_fixture_obj()
+        marc_records = srw_response.marc_records
+        assert len(marc_records) == 10
+        assert isinstance(marc_records[0], pymarc.record.Record)
+
+        # sanity check value from first and last record
+        marc_records[0]['001'] == 498910170
+        marc_records[-1]['001'] == 911727061

--- a/mep/books/tests/test_oclc.py
+++ b/mep/books/tests/test_oclc.py
@@ -66,14 +66,3 @@ class TestWorldCatClientBase(SimpleTestCase):
         mock_session.get.side_effect = requests.ConnectionError
         response = wc.search()
         assert response is None
-
-@patch('mep.books.oclc.WorldCatClientBase.search')
-class SrwResponse(TestCase):
-    with open(os.path.join(FIXTURES_DIR, 'sample-sru.response.xml'), 'rb') as fp:
-        xml_bytes = fp.read()
-
-    xml_string = xml_bytes.decode('utf-8')
-
-
-
-

--- a/mep/local_settings.py.sample
+++ b/mep/local_settings.py.sample
@@ -47,14 +47,18 @@ PUCAS_LDAP.update({
     'SEARCH_FILTER': "(uid=%(user)s)",
 })
 
-
-
 # username for accessing GeoNames API
 GEONAMES_USERNAME = ''
 
 # mapbox access token
 MAPBOX_ACCESS_TOKEN = ''
 
+# OCLC API key
+OCLC_WSKEY = ''
+
+# Email address for a technical contact.
+# Will be used in From header for OCLC API requests
+TECHNICAL_CONTACT = 'cdhdevteam@princeton.edu'
 
 # sample logging config for dev
 LOGGING = {

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 DJANGO_SETTINGS_MODULE=mep.settings
 # look for tests in standard django test location
 python_files = "mep/**/tests.py" "mep/**/tests/*.py"
+# limit testpath to speed up collecting step
+testpaths = mep

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ django-tabular-export
 django-webpack-loader
 parasolr>=0.2
 django-widget-tweaks
+pymarc

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ django-webpack-loader
 parasolr>=0.2
 django-widget-tweaks
 pymarc
+progressbar2


### PR DESCRIPTION
- OCLC search api logic
- manage command to iterate through items (with some exclusions), search for them in OCLC, look up work URI, and add to a CSV file
- moved partial date code into a separate file for convenience/better management
- added a custom lookup for `knownyear` on partial date precision field in the db
- added a method to get the first known event date for an item with no pub date