### PR TITLE
Chore/facet json

### DIFF
--- a/mep/common/views.py
+++ b/mep/common/views.py
@@ -3,8 +3,6 @@ from django.utils.cache import patch_vary_headers
 from django.views.generic.base import ContextMixin, TemplateResponseMixin, View
 from django.http import JsonResponse
 
-from parasolr.django import SolrQuerySet
-
 
 class LabeledPagesMixin(ContextMixin):
     '''View mixin to add labels for pages to a paginated view's context,
@@ -96,7 +94,7 @@ class FacetJSONMixin(TemplateResponseMixin, VaryOnHeadersMixin):
         '''Return a JsonResponse if the client asked for JSON, otherwise just
         call dispatch(). NOTE that this isn't currently smart enough to detect
         if the view's queryset is a SolrQuerySet; it will just break.'''
-        if self.request.META['HTTP_ACCEPT'] == 'application/json':
+        if self.request.META.get('HTTP_ACCEPT') == 'application/json':
             return self.render_facets(request, *args, **kwargs)
         return super(FacetJSONMixin, self).render_to_response(request, *args, **kwargs)
 

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -12,14 +12,14 @@ from django.views.generic.edit import FormView, FormMixin
 
 from mep.accounts.models import Event
 from mep.common.utils import alpha_pagelabels
-from mep.common.views import LabeledPagesMixin, AjaxTemplateMixin
+from mep.common.views import LabeledPagesMixin, AjaxTemplateMixin, FacetJSONMixin
 from mep.people.forms import PersonMergeForm, MemberSearchForm
 from mep.people.geonames import GeoNamesAPI
 from mep.people.models import Country, Location, Person
 from mep.people.queryset import PersonSolrQuerySet
 
 
-class MembersList(LabeledPagesMixin, ListView, FormMixin, AjaxTemplateMixin):
+class MembersList(LabeledPagesMixin, ListView, FormMixin, AjaxTemplateMixin, FacetJSONMixin):
     '''List page for searching and browsing library members.'''
     model = Person
     template_name = 'people/member_list.html'


### PR DESCRIPTION
this PR adds a `FacetJSONMixin` that can respond with a `JsonResponse` containing the facets from a `SolrQuerySet` if the http request `Accept:` header is set to `application/json`.