### PR TITLE
Feature/async choice facet

### DIFF
--- a/mep/common/forms.py
+++ b/mep/common/forms.py
@@ -65,8 +65,7 @@ class FacetForm(forms.Form):
                 self.fields[formfield].choices = [
                     # iterate over val and counts in counts dictionary
                     # and format as a lable and comma separated integer
-                    (val, mark_safe('<span class="label">{}</span> '
-                                    '<span class="count">{:,}</span>'\
+                    (val, mark_safe('{}<span class="count">{:,}</span>'\
                                     .format(val if val else 'Unknown', count)))
                     for val, count in counts.items()
                 ]

--- a/mep/common/templates/common/widgets/checkbox_fieldset.html
+++ b/mep/common/templates/common/widgets/checkbox_fieldset.html
@@ -7,11 +7,15 @@
 {% endcomment%}
 <fieldset class="facet"{% include "django/forms/widgets/attrs.html" %}>
 <legend>{{ widget.legend }}</legend>
+<ul class="choices">
 {% for group, options, index in widget.optgroups %}
-        {% for option in options %}
+    {% for option in options %}
+    <li class="choice">
         {# includes a revised version of Django's attr snippet to remove legend #}
         <input type="checkbox" value="{{ option.value }}" id="{{ option.attrs.id }}" name="{{ widget.name }}" {% if widget.required %}required{% endif %} {% if option.attrs.checked %}checked{% endif %}>
         <label for="{{ option.attrs.id }}"> {{ option.label }} </label>
+    </li>
     {% endfor %}
 {% endfor %}
-    </fieldset>
+</ul>
+</fieldset>

--- a/mep/people/forms.py
+++ b/mep/people/forms.py
@@ -99,9 +99,7 @@ class MemberSearchForm(FacetForm):
         library records are available.')
     # NOTE: Temporarily make submit on every click, for testing before adding
     # to reactive search
-    sex = FacetChoiceField(label='Sex', widget=CheckboxFieldset(attrs={
-        'onchange': 'this.form.submit()'
-    }))
+    sex = FacetChoiceField(label='Gender', widget=CheckboxFieldset())
 
     def __init__(self, data=None, *args, **kwargs):
         '''

--- a/mep/people/forms.py
+++ b/mep/people/forms.py
@@ -97,8 +97,6 @@ class MemberSearchForm(FacetForm):
         }),
         help_text='This filter will narrow results to show only members whose \
         library records are available.')
-    # NOTE: Temporarily make submit on every click, for testing before adding
-    # to reactive search
     sex = FacetChoiceField(label='Gender', widget=CheckboxFieldset())
 
     def __init__(self, data=None, *args, **kwargs):

--- a/srcmedia/scss/search/_facet.scss
+++ b/srcmedia/scss/search/_facet.scss
@@ -9,10 +9,20 @@
 
     > legend {
         position: absolute;
-        top: 0.7rem;
+        top: 0.75rem;
         left: 0.7rem;
         padding: 0;
         display: block;
+    }
+
+    .choices {
+        height: 100%;
+        padding-top: 1.5rem;
+        list-style: none;
+    }
+
+    .choice:hover {
+        background: #f1f1f1;
     }
     
     legend,
@@ -21,28 +31,18 @@
         font-size: 0.8rem;
         display: block;
         text-align: left;
-        height: fit-content;
         margin: 0;
         border: 0;
+        padding: 0 0.5rem;
     }
 
     label {
-        padding: 0 .5rem;
         color: $brownish-grey;
         cursor: pointer;
         display: flex;
         justify-content: space-between;
         align-items: center;
         transition: padding 0.25s ease;
-
-        &:hover {
-            background: #f1f1f1;
-        }
-
-        &:first-of-type {
-            margin-top: 1.4rem;
-            padding-top: 0;
-        }
 
         &::before {
             content: '';
@@ -57,14 +57,6 @@
             background-position: center;
             pointer-events: none;
             transition: opacity 0.25s ease;
-        }
-
-        .label,
-        .count {
-            display: inline-flex;
-            height: 1.2rem;
-            line-height: 1.2rem;
-            padding-top: .2rem; // to make the text to vertically center correctly :(
         }
 
         .count {

--- a/srcmedia/ts/lib/common.ts
+++ b/srcmedia/ts/lib/common.ts
@@ -97,10 +97,10 @@ function getTransitionDuration (element: HTMLElement): number {
     return isNaN(parsed) ? 0 : parsed
 }
 
-abstract class Rx<Element> {
-    element: Element
+abstract class Rx<E extends HTMLElement> {
+    protected element: E
     
-    constructor(element: Element) {
+    constructor(element: E) {
         this.element = element
     }
 }

--- a/srcmedia/ts/lib/facet.test.ts
+++ b/srcmedia/ts/lib/facet.test.ts
@@ -1,34 +1,80 @@
 import { Subject } from 'rxjs'
 
-import { RxBooleanFacet } from './facet'
+import { RxBooleanFacet, RxChoiceFacet } from './facet'
 
-beforeEach(() => {
-    document.body.innerHTML = `
-    <input id="facet" type="checkbox" name="has_card"/>
-    <label for="facet">Card<span class="count">0</span></label>
-    `
-})
-
-it('stores its count as an observable sequence', () => {
-    let $facet = document.querySelector('#facet') as HTMLInputElement
-    let rbf = new RxBooleanFacet($facet)
-    expect(rbf.count).toBeInstanceOf(Subject)
-})
-
-it('keeps a reference to the count in its label', () => {
-    let $facet = document.querySelector('#facet') as HTMLInputElement
-    let $count = document.querySelector('.count') as HTMLSpanElement
-    let rbf = new RxBooleanFacet($facet)
-    expect(rbf.countElement).toBe($count)
-})
-
-it('updates the count element when its count is updated', () => {
-    let $facet = document.querySelector('#facet') as HTMLInputElement
-    let $count = document.querySelector('.count') as HTMLSpanElement
-    let rbf = new RxBooleanFacet($facet)
-    rbf.count.subscribe(() => {
-        expect($count.innerHTML).toBe('55')
+describe('RxBooleanFacet', () => {
+    
+    beforeEach(() => {
+        document.body.innerHTML = `
+        <input id="facet" type="checkbox" name="has_card"/>
+        <label for="facet">Card<span class="count">0</span></label>
+        `
     })
-    rbf.count.next(55)
+    
+    it('stores its count as an observable sequence', () => {
+        let $facet = document.querySelector('#facet') as HTMLInputElement
+        let rbf = new RxBooleanFacet($facet)
+        expect(rbf.count).toBeInstanceOf(Subject)
+    })
+    
+    it('keeps a reference to the count in its label', () => {
+        let $facet = document.querySelector('#facet') as HTMLInputElement
+        let $count = document.querySelector('.count') as HTMLSpanElement
+        let rbf = new RxBooleanFacet($facet)
+        expect(rbf.countElement).toBe($count)
+    })
+    
+    it('updates the count element when its count is updated', () => {
+        let $facet = document.querySelector('#facet') as HTMLInputElement
+        let $count = document.querySelector('.count') as HTMLSpanElement
+        let rbf = new RxBooleanFacet($facet)
+        rbf.count.subscribe(() => {
+            expect($count.innerHTML).toBe('55')
+        })
+        rbf.count.next(55)
+    })
 })
+
+describe('RxChoiceFacet', () => {
+
+    beforeEach(() => {
+        document.body.innerHTML = `
+        <fieldset class="facet">
+            <legend>fruits<legend>
+            <ul>
+                <li>
+                    <input id="banana" name="fruits" value="banana" type="checkbox">
+                    <label for="banana">banana<span class="count">15</span></label>
+                </li>
+            </ul>
+        </fieldset>`
+    })
+
+    it('updates its counts when new ones are supplied', () => {
+        const $facet = document.querySelector('.facet') as HTMLFieldSetElement
+        const $bananaCountEl = document.querySelector('label[for=banana] .count') as HTMLSpanElement
+        const rcf = new RxChoiceFacet($facet)
+        rcf.counts.subscribe(() => expect($bananaCountEl.innerHTML).toBe('20'))
+        rcf.counts.next(['banana', 20])
+    })
+
+    it('displays counts using comma formatting', () => {
+        const $facet = document.querySelector('.facet') as HTMLFieldSetElement
+        const $bananaCountEl = document.querySelector('label[for=banana] .count') as HTMLSpanElement
+        const rcf = new RxChoiceFacet($facet)
+        rcf.counts.subscribe(() => expect($bananaCountEl.innerHTML).toBe('2,942'))
+        rcf.counts.next(['banana', 2942])
+    })
+
+    it('publishes events when the user makes a choice', () => {
+        const $facet = document.querySelector('.facet') as HTMLFieldSetElement
+        const $banana = document.querySelector('#banana') as HTMLInputElement
+        const rcf = new RxChoiceFacet($facet)
+        const watcher = jest.fn()
+        rcf.events.subscribe(watcher)
+        $banana.dispatchEvent(new Event('input', { bubbles: true }))
+        expect(watcher).toHaveBeenCalled()
+    })
+})
+
 

--- a/srcmedia/ts/lib/facet.ts
+++ b/srcmedia/ts/lib/facet.ts
@@ -44,6 +44,17 @@ class RxBooleanFacet extends RxCheckboxInput {
     }
 }
 
+/**
+ * A choice facet consisting of multiple checkboxes where the user always
+ * has access to all the choices.
+ * 
+ * This facet is similar to a text facet, but intended for use where there are
+ * a limited number of choices that should always be displayed, regardless
+ * of counts.
+ *
+ * @class RxChoiceFacet
+ * @extends {Rx<HTMLFieldSetElement>}
+ */
 class RxChoiceFacet extends Rx<HTMLFieldSetElement> {
     
     protected $inputs: Array<HTMLInputElement>

--- a/srcmedia/ts/lib/facet.ts
+++ b/srcmedia/ts/lib/facet.ts
@@ -1,7 +1,7 @@
-import { Subject } from 'rxjs'
+import { Observable, Subject, fromEvent, merge } from 'rxjs'
 
 import { RxCheckboxInput } from './input'
-import { animateElementContent } from './common'
+import { Rx, animateElementContent } from './common'
 
 /**
  * A boolean (checkbox) facet that can update the count in its <label>.
@@ -20,8 +20,10 @@ class RxBooleanFacet extends RxCheckboxInput {
         super(element)
         this.count = new Subject()
         // assume the count is an element inside the label with class 'count'
-        if (this.label) this.countElement = this.label.querySelector('.count')
-        this.count.subscribe(this.updateCount)
+        if (this.label) {
+            this.countElement = this.label.querySelector('.count')
+            this.count.subscribe(this.updateCount)
+        }
     }
 
     /**
@@ -35,10 +37,49 @@ class RxBooleanFacet extends RxCheckboxInput {
      * @memberof RxBooleanFacet
      */
     protected updateCount = async (count: number): Promise<string> => {
-        return animateElementContent(this.element, count.toLocaleString())
+        if (this.countElement) {
+            return animateElementContent(this.countElement, count.toLocaleString())
+        }
+        return count.toLocaleString()
+    }
+}
+
+class RxChoiceFacet extends Rx<HTMLFieldSetElement> {
+    
+    protected $inputs: Array<HTMLInputElement>
+    public counts: Subject<[string, number]> // input from solr
+    public events: Observable<Event>
+
+    constructor (element: HTMLFieldSetElement) {
+        super(element)
+        // find and save all the <input>s associated with this facet
+        this.$inputs = Array.from(this.element.getElementsByTagName('input'))
+        this.counts = new Subject()
+        // keep track of the user's selections so we can tell the form to update
+        this.events = merge(...this.$inputs.map($input => fromEvent($input, 'input')))
+        this.counts.subscribe(this.updateCount)
+    }
+
+    /**
+     * Finds the relevant count element for each choice input and calls
+     * animateElementContent() to swap out the number displayed in it.
+     * 
+     * Assumes the input has exactly one <label> that contains a <span> with
+     * class 'count'.
+     *
+     * @protected
+     * @memberof RxChoiceFacet
+     */
+    protected updateCount = async ([label, count]: [string, number]): Promise<void> => {
+        const value = (label == 'null' ? '' : label) // solr 'null' becomes empty value ""
+        const $input = this.$inputs.find($input => $input.value == value)
+        //@ts-ignore
+        const $count = $input.labels[0].querySelector('.count') as HTMLSpanElement
+        await animateElementContent($count, count.toLocaleString())
     }
 }
 
 export {
     RxBooleanFacet,
+    RxChoiceFacet
 }


### PR DESCRIPTION
this PR:
- removes the automatic submission bindings from the gender facet
- adds an `RxChoiceFacet` class designed for handling facets like the gender facet, where all choices should be displayed to the user regardless of counts
- implements reactivity for the gender facet using `RxChoiceFacet`
- switches the "has card" facet to fully using `RxBooleanFacet`, since it wasn't actually doing so before (oops!)