### PR TITLE
Simplify model repr methods

### DIFF
--- a/mep/accounts/tests/test_accounts_models.py
+++ b/mep/accounts/tests/test_accounts_models.py
@@ -327,10 +327,13 @@ class TestEvent(TestCase):
         self.event = Event.objects.create(account=self.account)
 
     def test_repr(self):
-        # Using self.__dict__ so relying on method being correct
-        # Testing for form of "<Account {"k":v, ...}>"
-        overall = re.compile(r"<Event \{.+\}>")
-        assert re.search(overall, repr(self.event))
+        assert repr(self.event) == '<Event pk:%s account:%s %s>' % \
+            (self.event.pk, self.account.pk, self.event.date_range)
+
+        # test one subclass
+        borrow = Borrow.objects.create(account=self.account, item=self.item)
+        assert repr(borrow) == '<Borrow pk:%s account:%s %s>' % \
+            (borrow.pk, self.account.pk, borrow.date_range)
 
     def test_str(self):
         assert str(self.event) == \
@@ -444,12 +447,6 @@ class TestSubscription(TestCase):
             volumes=2,
             price_paid=3.20
         )
-
-    def test_repr(self):
-        # Using self.__dict__ so relying on method being correct
-        # Testing for form of "<Account {"k":v, ...}>"
-        overall = re.compile(r"<Subscription \{.+\}>")
-        assert re.search(overall, repr(self.subscription))
 
     def test_str(self):
         assert str(self.subscription) == \
@@ -649,12 +646,6 @@ class TestPurchase(TestCase):
         self.purchase.calculate_date('start_date', '1920-02-03')
         self.purchase.save()
 
-    def test_repr(self):
-        # Using self.__dict__ so relying on method being correct
-        # Testing for form of "<Account {"k":v, ...}>"
-        overall = re.compile(r"<Purchase \{.+\}>")
-        assert re.search(overall, repr(self.purchase))
-
     def test_str(self):
         assert str(self.purchase) == ('Purchase for account #%s 1920-02-03' %
                                       self.purchase.account.pk)
@@ -710,15 +701,9 @@ class TestReimbursement(TestCase):
             currency='USD',
         )
 
-    def test_repr(self):
-        # Using self.__dict__ so relying on method being correct
-        # Testing for form of "<Account {"k":v, ...}>"
-        overall = re.compile(r"<Reimbursement \{.+\}>")
-        assert re.search(overall, repr(self.reimbursement))
-
     def test_str(self):
-        assert str(self.reimbursement) == ('Reimbursement for account #%s ??/??' %
-                                            self.reimbursement.account.pk)
+        assert str(self.reimbursement) == 'Reimbursement for account #%s ??/??' % \
+            self.reimbursement.account.pk
 
     def test_date(self):
         self.reimbursement.start_date = datetime.date(1920, 1, 1)
@@ -763,12 +748,6 @@ class TestBorrow(TestCase):
         self.borrow = Borrow.objects.create(
             account=self.account, item=self.item
         )
-
-    def test_repr(self):
-        # Using self.__dict__ so relying on method being correct
-        # Testing for form of "<Account {"k":v, ...}>"
-        overall = re.compile(r"<Borrow \{.+\}>")
-        assert re.search(overall, repr(self.borrow))
 
     def test_str(self):
         assert str(self.borrow) == ('Borrow for account #%s ??/??' %

--- a/mep/accounts/tests/test_accounts_models.py
+++ b/mep/accounts/tests/test_accounts_models.py
@@ -19,10 +19,20 @@ class TestAccount(TestCase):
 
     def test_repr(self):
         account = Account()
-        # Using self.__dict__ so relying on method being correct
-        # Testing for form of "<Account {"k":v, ...}>""
-        overall = re.compile(r"<Account \{.+\}>")
-        assert re.search(overall, repr(account))
+        # unsaved
+        assert repr(account) == '<Account pk:??>'
+        # saved but no names
+        account.save()
+        assert repr(account) == '<Account pk:%s>' % account.pk
+        # one name
+        pers1 = Person.objects.create(name='Mlle Foo')
+        account.persons.add(pers1)
+        assert repr(account) == '<Account pk:%s %s>' % (account.pk, str(pers1))
+        # multiple names
+        pers2 = Person.objects.create(name='Bazbar')
+        account.persons.add(pers2)
+        assert repr(account) == '<Account pk:%s %s;%s>' % \
+            (account.pk, str(pers1), str(pers2))
 
     def test_str(self):
         # create and save an account
@@ -242,10 +252,11 @@ class TestAddress(TestCase):
         )
 
     def test_repr(self):
-        # Using self.__dict__ so relying on method being correct
-        # Testing for form of "<Account {"k":v, ...}>"
-        overall = re.compile(r"<Address \{.+\}>")
-        assert re.search(overall, repr(self.address))
+        new_addr = Address(location=self.location)
+        assert repr(new_addr) == '<Address pk:?? %s>' % new_addr
+
+        assert repr(self.address) == '<Address pk:%s %s>' % \
+            (self.address.pk, self.address)
 
     def test_str(self):
         # account only

--- a/mep/books/models.py
+++ b/mep/books/models.py
@@ -174,7 +174,8 @@ class Item(Notable, Indexable):
         super(Item, self).save(*args, **kwargs)
 
     def __repr__(self):
-        return '<Item %s>' % self.__dict__
+        # provide pk for easy lookup and string for recognition
+        return '<Item pk:%s %s>' % (self.pk or '??', str(self))
 
     def __str__(self):
         year_str = ''

--- a/mep/books/tests/test_books_models.py
+++ b/mep/books/tests/test_books_models.py
@@ -17,8 +17,11 @@ class TestItem(TestCase):
 
     def test_repr(self):
         item = Item(title='Le foo et le bar', year=1916)
-        overall = re.compile(r"<Item \{.+\}>")
-        assert re.search(overall, repr(item))
+        # unsaved
+        assert repr(item) == '<Item pk:?? %s>' % item
+        # saved
+        item.save()
+        assert repr(item) == '<Item pk:%s %s>' % (item.pk, item)
 
     def test_str(self):
 

--- a/mep/books/tests/test_books_models.py
+++ b/mep/books/tests/test_books_models.py
@@ -204,30 +204,6 @@ class TestItem(TestCase):
         assert item.has_uri()
 
 
-class TestPublisher(TestCase):
-
-    def test_repr(self):
-        publisher = Publisher(name='Foo, Bar, and Co.')
-        overall = re.compile(r"<Publisher \{.+\}>")
-        assert re.search(overall, repr(publisher))
-
-    def test_str(self):
-        publisher = Publisher(name='Foo, Bar, and Co.')
-        assert str(publisher) == 'Foo, Bar, and Co.'
-
-
-class TestPublisherPlace(TestCase):
-
-    def test_repr(self):
-        pub_place = PublisherPlace(name='London', latitude=23, longitude=45)
-        overall = re.compile(r"<PublisherPlace \{.+\}>")
-        assert re.search(overall, repr(pub_place))
-
-    def test_str(self):
-        pub_place = PublisherPlace(name='London', latitude=23, longitude=45)
-        assert str(pub_place) == 'London'
-
-
 class TestCreator(TestCase):
 
     def test_str(self):

--- a/mep/common/models.py
+++ b/mep/common/models.py
@@ -43,7 +43,8 @@ class Named(models.Model):
         ordering = ['name']
 
     def __repr__(self):
-        return '<%s %s>' % (self.__class__.__name__, self.__dict__)
+        # name is unique, so should be sufficient to identify
+        return '<%s %s>' % (self.__class__.__name__, self.name)
 
     def __str__(self):
         return self.name

--- a/mep/common/tests.py
+++ b/mep/common/tests.py
@@ -28,10 +28,19 @@ class TestNamed(TestCase):
     def test_repr(self):
         named_obj = Named(name='foo')
         assert repr(named_obj) == '<Named %s>' % named_obj.name
+        # subclass
+
+        class MyName(Named):
+            pass
+
+        mynamed = MyName(name='bar')
+        assert repr(mynamed) == '<MyName %s>' % mynamed.name
 
     def test_str(self):
         named_obj = Named(name='foo')
         assert str(named_obj) == 'foo'
+
+
 
 
 class TestNotable(TestCase):

--- a/mep/common/tests.py
+++ b/mep/common/tests.py
@@ -27,8 +27,7 @@ class TestNamed(TestCase):
 
     def test_repr(self):
         named_obj = Named(name='foo')
-        overall = re.compile(r'<Named \{.+\}>')
-        assert re.search(overall, repr(named_obj))
+        assert repr(named_obj) == '<Named %s>' % named_obj.name
 
     def test_str(self):
         named_obj = Named(name='foo')

--- a/mep/footnotes/admin.py
+++ b/mep/footnotes/admin.py
@@ -4,8 +4,8 @@ from django.contrib.contenttypes.admin import GenericTabularInline
 
 from dal import autocomplete
 
-from mep.common.admin import AUTOCOMPLETE, NamedNotableAdmin
-from .models import SourceType, Bibliography, Footnote
+from mep.common.admin import NamedNotableAdmin
+from mep.footnotes.models import SourceType, Bibliography, Footnote
 
 
 class FootnoteAdminForm(forms.ModelForm):
@@ -36,7 +36,7 @@ class FootnoteAdmin(admin.ModelAdmin):
         }),
         (None, {
             'fields': ('bibliography', 'location', 'snippet_text', 'is_agree',
-                'notes')
+                       'notes')
         })
     ]
 

--- a/mep/people/models.py
+++ b/mep/people/models.py
@@ -77,7 +77,7 @@ class Location(Notable):
         unique_together = (("name", "street_address", "city", "country"),)
 
     def __repr__(self):
-        return '<Location %s>' % self.__dict__
+        return '<Location pk:%s %s>' % (self.pk or '??', str(self))
 
     def __str__(self):
         str_parts = [self.name, self.street_address, self.city]
@@ -86,7 +86,6 @@ class Location(Notable):
 
 class Profession(Named, Notable):
     '''Profession for a :class:`Person`'''
-    pass
 
 
 class PersonQuerySet(models.QuerySet):
@@ -278,7 +277,7 @@ class Person(Notable, DateRange, Indexable):
     objects = PersonQuerySet.as_manager()
 
     def __repr__(self):
-        return '<Person %s>' % self.__dict__
+        return '<Person pk:%s %s>' % (self.pk or '??', self.sort_name)
 
     def __str__(self):
         '''String representation; use sort name if available with fall back
@@ -448,7 +447,7 @@ class InfoURL(Notable):
         verbose_name = 'Informational URL'
 
     def __repr__(self):
-        return "<InfoURL %s>" % self.__dict__
+        return "<InfoURL pk:%s %s>" % (self.pk or '??', self.url)
 
     def __str__(self):
         return self.url
@@ -456,7 +455,6 @@ class InfoURL(Notable):
 
 class RelationshipType(Named, Notable):
     '''Types of relationships between one :class:`Person` and another'''
-    pass
 
 
 class Relationship(Notable):

--- a/mep/people/tests/test_models.py
+++ b/mep/people/tests/test_models.py
@@ -20,6 +20,23 @@ from mep.people.models import (Country, InfoURL, Location, Person, Profession,
                                Relationship, RelationshipType)
 
 
+class TestLocation(TestCase):
+
+    def test_repr(self):
+        loc = Location(name='L\'Hotel', city='Paris')
+        # unsaved
+        assert repr(loc) == '<Location pk:?? %s>' % str(loc)
+        # saved
+        loc.save()
+        assert repr(loc) == '<Location pk:%s %s>' % (loc.pk, str(loc))
+
+    def test_str(self):
+        hotel = Location.objects.create(name='L\'Hotel')
+        assert str(hotel) == hotel.name
+        paris_hotel = Location.objects.create(name='L\'Hotel', city='Paris')
+        assert str(paris_hotel) == '%s, %s' % (paris_hotel.name, paris_hotel.city)
+
+
 class TestPerson(TestCase):
 
     def test_str(self):
@@ -44,12 +61,13 @@ class TestPerson(TestCase):
         assert str(foo_bar) == 'Mr. Bar'
 
     def test_repr(self):
-        # Foo Bar, born 1900
-        person_foo = Person(name='Foo', sort_name='Bar, Foo', birth_year=1900)
-        # Using self.__dict__ so relying on method being correct
-        # Testing for form of "<Person {'k':v, ...}>""
-        overall = re.compile(r'<Person \{.+\}>')
-        assert re.search(overall, repr(person_foo))
+        person_foo = Person(name='Foo', sort_name='Bar, Foo')
+        # unsaved
+        assert repr(person_foo) == '<Person pk:?? %s>' % person_foo.sort_name
+        # saved
+        person_foo.save()
+        assert repr(person_foo) == '<Person pk:%s %s>' % \
+            (person_foo.pk, person_foo.sort_name)
 
     def test_viaf(self):
         pers = Person(name='Beach')
@@ -508,18 +526,6 @@ class TestPersonQuerySet(TestCase):
         assert 'association will be lost in merge' in logs.output[0]
 
 
-class TestProfession(TestCase):
-
-    def test_repr(self):
-        carpenter = Profession(name='carpenter')
-        overall = re.compile(r'<Profession \{.+\}>')
-        assert re.search(overall, repr(carpenter))
-
-    def test_str(self):
-        carpenter = Profession(name='carpenter')
-        assert str(carpenter) == 'carpenter'
-
-
 class TestRelationship(TestCase):
 
     def setUp(self):
@@ -541,17 +547,6 @@ class TestRelationship(TestCase):
             "'to_person': <Person Bar>, "
             "'relationship_type': <RelationshipType sibling>}>"
         )
-
-
-class TestRelationshipType(TestCase):
-    def test_repr(self):
-        sib = RelationshipType(name='sibling')
-        overall = re.compile(r'<RelationshipType \{.+\}>')
-        assert re.search(overall, repr(sib))
-
-    def test_str(self):
-        sib = RelationshipType(name='sibling')
-        assert str(sib) == 'sibling'
 
 
 class TestRelationshipM2M(TestCase):
@@ -644,14 +639,16 @@ class TestAddress(TestCase):
 class TestInfoURL(TestCase):
 
     def test_str(self):
-        p = Person.objects.create(name='Someone')
-        info_url = InfoURL(person=p, url='http://example.com/')
+        pers = Person.objects.create(name='Someone')
+        info_url = InfoURL(person=pers, url='http://example.com/')
         assert str(info_url) == info_url.url
 
     def test_repr(self):
-        p = Person.objects.create(name='Someone')
-        info_url = InfoURL(person=p, url='http://example.com/')
-        assert repr(info_url).startswith('<InfoURL ')
-        assert repr(info_url).endswith('>')
-        assert info_url.url in repr(info_url)
-        assert str(p) in repr(info_url)
+        pers = Person.objects.create(name='Someone')
+        info_url = InfoURL(person=pers, url='http://example.com/')
+        # unsaved
+        assert repr(info_url) == '<InfoURL pk:?? %s>' % info_url.url
+        # saved
+        info_url.save()
+        assert repr(info_url) == '<InfoURL pk:%s %s>' % \
+            (info_url.pk, info_url.url)


### PR DESCRIPTION
Refactors `repr` methods for models across the app to make them shorter and more readable and usable for debugging. 