### PR TITLE
books search form

### DIFF
--- a/mep/books/forms.py
+++ b/mep/books/forms.py
@@ -1,0 +1,19 @@
+from django import forms
+
+from mep.common.forms import FacetForm, SelectWithDisabled
+
+
+class ItemSearchForm(FacetForm):
+    '''Book search form'''
+
+    SORT_CHOICES = [
+        ('relevance', 'Relevance'),
+        ('title', 'Title A-Z'),
+    ]
+
+    # NOTE these are not set by default!
+    error_css_class = 'error'
+    required_css_class = 'required'
+
+    sort = forms.ChoiceField(choices=SORT_CHOICES, required=False,
+                             widget=SelectWithDisabled)

--- a/mep/books/templates/books/item_list.html
+++ b/mep/books/templates/books/item_list.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static humanize %}
+{% load static humanize widget_tweaks %}
 {% load render_bundle from webpack_loader %}
 
 {% block js %}{% render_bundle 'booksSearch' 'js' %}{% endblock %}
@@ -16,7 +16,21 @@
 <section class="books search-form">
     {% include 'snippets/breadcrumbs.html' %}
     <form id="books-form">
-        <span class="total-results">{{ items.count|intcomma }} total result{{ items.count|pluralize }}</span>
+        {% if form.errors %}
+        <div role="alert" class="errors" aria-labelledby="errors" aria-live="polite">
+            <span id="errors">Errors:</span>
+            <ul>
+                {% for field, errors in form.errors.items %}
+                {# no clean way to get field labels here, so we just collapse the error lists #}
+                {% for error in errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            {% endfor %}
+            </ul>
+        </div>
+        {% endif %}
+        <input type="submit" value="submit"/>
+        <output class="total-results" id="total">{{ items.count|intcomma }} total result{{ items.count|pluralize }}</output>
     </form>
 </section>
 <div class="upper-labels"> {# only shown on mobile & tablet before the user scrolls down #}
@@ -27,9 +41,7 @@
     <div class="inner">
         <label class="sort">
             <span>SORTED BY</span>
-            <select name="sort" form="books-form">
-                <option selected>Title A-Z</option>
-            </select>
+            {% render_field form.sort form="books-form" %}
             <img class="dropdown icon" src="{% static 'img/icons/chevron_down.png' %}" alt="">
         </label>
         <button type="submit" form="books-form">Go</button>

--- a/mep/books/templates/books/item_list.html
+++ b/mep/books/templates/books/item_list.html
@@ -16,19 +16,7 @@
 <section class="books search-form">
     {% include 'snippets/breadcrumbs.html' %}
     <form id="books-form">
-        {% if form.errors %}
-        <div role="alert" class="errors" aria-labelledby="errors" aria-live="polite">
-            <span id="errors">Errors:</span>
-            <ul>
-                {% for field, errors in form.errors.items %}
-                {# no clean way to get field labels here, so we just collapse the error lists #}
-                {% for error in errors %}
-                    <li>{{ error }}</li>
-                {% endfor %}
-            {% endfor %}
-            </ul>
-        </div>
-        {% endif %}
+        {% include 'common/form_errors.html' %}
         <input type="submit" value="submit"/>
         <output class="total-results" id="total">{{ items.count|intcomma }} total result{{ items.count|pluralize }}</output>
     </form>

--- a/mep/books/tests/test_books_views.py
+++ b/mep/books/tests/test_books_views.py
@@ -1,10 +1,13 @@
 import time
+from unittest.mock import Mock
 
 from django.contrib.auth import get_user_model
+from django.core.paginator import Paginator
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 
 from mep.books.models import Item
+from mep.books.views import ItemList
 
 
 class TestBooksViews(TestCase):
@@ -61,13 +64,15 @@ class TestItemListView(TestCase):
     fixtures = ['sample_items.json', 'multi_creator_item.json']
 
     def setUp(self):
+        # index fixtures and give time for index to take effect
         Item.index_items(Item.objects.all())
-        # give time for index to take effect
         time.sleep(10)
+        # bind some convenience items
+        self.factory = RequestFactory()
+        self.url = reverse('books:books-list')
 
     def test_list(self):
-        url = reverse('books:books-list')
-        response = self.client.get(url)
+        response = self.client.get(self.url)
 
         # should display all items in the database
         items = Item.objects.all()
@@ -82,12 +87,10 @@ class TestItemListView(TestCase):
         # NOTE publishers display is designed but data not yet available
 
     def test_many_authors(self):
-        url = reverse('books:books-list')
-        response = self.client.get(url)
-
-        novelists = Item.objects.get(pk=4126)
+        response = self.client.get(self.url)
 
         # multi-author item should show first three authors
+        novelists = Item.objects.get(pk=4126)
         self.assertContains(response, novelists.authors.first())
         self.assertContains(response, novelists.authors[1])
         self.assertContains(response, novelists.authors[2])
@@ -97,3 +100,42 @@ class TestItemListView(TestCase):
 
         # should show "...x more authors" text
         self.assertContains(response, '... 16 more authors')
+
+    def test_get_queryset(self):
+        # create a mocked form
+        view = ItemList()
+        form = Mock()
+        view.get_form = Mock(return_value=form)
+        view.request = self.factory.get(self.url)
+        # if form is valid, should return all items sorted by chosen sort
+        form.is_valid.return_value = True
+        form.cleaned_data = {'sort': 'title'}  # becomes 'title_s'
+        solr_qs = view.get_queryset()
+        db_qs = Item.objects.order_by('title')
+        # querysets from solr and db should match
+        for index, item in enumerate(solr_qs):
+            assert db_qs[index].title == item['title']
+            assert db_qs[index].pk == item['pk']
+        # if form is invalid, should return empty queryset
+        form.is_valid.return_value = False
+        solr_qs = view.get_queryset()
+        # NOTE replace with EmptySolrQueryset check when implemented in parasolr
+        assert solr_qs.count() == 0
+
+    def test_get_page_labels(self):
+        # create a mocked form and some fake items to paginate
+        view = ItemList()
+        form = Mock()
+        view.get_form = Mock(return_value=form)
+        view.request = self.factory.get(self.url)
+        items = range(120)
+        paginator = Paginator(items, per_page=view.paginate_by)
+        # if form is valid, should use default implementation (numbered pages)
+        # NOTE this will change if we implement alpha pagination for this view
+        form.is_valid.return_value = True
+        page_labels = view.get_page_labels(paginator)
+        assert page_labels == [(1, '1 - 100'), (2, '101 - 120')]
+        # if invalid, should return one page with 'N/A' label
+        form.is_valid.return_value = False
+        page_labels = view.get_page_labels(paginator)
+        assert page_labels == [(1, 'N/A')]

--- a/mep/books/tests/test_books_views.py
+++ b/mep/books/tests/test_books_views.py
@@ -34,7 +34,7 @@ class TestBooksViews(TestCase):
 
         # search by title
         item1 = Item.objects.create(title='Poems Two Painters', mep_id='mep:01',
-            notes='Author: Knud Merrild')
+                                    notes='Author: Knud Merrild')
         item2 = Item.objects.create(title='Collected Poems', mep_id='mep:02')
         res = self.client.get(url, {'q': 'poems'})
         data = res.json()
@@ -55,6 +55,7 @@ class TestBooksViews(TestCase):
         data = res.json()
         assert len(data['results']) == 1
         assert data['results'][0]['text'] == item2.title
+
 
 class TestItemListView(TestCase):
     fixtures = ['sample_items.json', 'multi_creator_item.json']

--- a/mep/books/views.py
+++ b/mep/books/views.py
@@ -49,6 +49,7 @@ class ItemList(LabeledPagesMixin, ListView, FormMixin, AjaxTemplateMixin, FacetJ
     }
 
     def get_queryset(self):
+        # NOTE faceting on pub date currently as a placeholder; no UI use yet
         sqs = ItemSolrQuerySet().facet_field('pub_date_i')
         form = self.get_form()
 

--- a/mep/books/views.py
+++ b/mep/books/views.py
@@ -1,26 +1,84 @@
 from dal import autocomplete
 from django.db.models import Q
-from django.views.generic import DetailView, ListView
 from django.urls import reverse
+from django.views.generic import DetailView, ListView
+from django.views.generic.edit import FormMixin
 
+from mep.books.forms import ItemSearchForm
 from mep.books.models import Item
 from mep.books.queryset import ItemSolrQuerySet
-from mep.common.views import LabeledPagesMixin, RdfViewMixin
-from mep.common.utils import absolutize_url
 from mep.common import SCHEMA_ORG
+from mep.common.utils import absolutize_url, alpha_pagelabels
+from mep.common.views import (AjaxTemplateMixin, FacetJSONMixin,
+                              LabeledPagesMixin, RdfViewMixin)
 
 
-class ItemList(LabeledPagesMixin, ListView, RdfViewMixin):
+class ItemList(LabeledPagesMixin, ListView, FormMixin, AjaxTemplateMixin, FacetJSONMixin, RdfViewMixin):
     '''List page for searching and browsing library items.'''
     model = Item
     template_name = 'books/item_list.html'
+    ajax_template_name = 'books/snippets/item_results.html'
     paginate_by = 100
     context_object_name = 'items'
     rdf_type = SCHEMA_ORG.SearchResultPage
 
-    def get_queryset(self):
-        return ItemSolrQuerySet().order_by('title')
+    form_class = ItemSearchForm
+    _form = None
+    initial = {'sort': 'title'}
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        form_data = self.request.GET.copy()
+
+        # set defaults
+        for key, val in self.initial.items():
+            form_data.setdefault(key, val)
+
+        kwargs['data'] = form_data
+        return kwargs
+
+    def get_form(self, *args, **kwargs):
+        if not self._form:
+            self._form = super().get_form(*args, **kwargs)
+        return self._form
+
+    # map form sort to solr sort
+    solr_sort = {
+        'relevance': '-score',
+        'title': 'title_s',
+    }
+
+    def get_queryset(self):
+        sqs = ItemSolrQuerySet().facet_field('pub_date_i')
+        form = self.get_form()
+
+        # empty qs if not valid
+        if not form.is_valid():
+            sqs = sqs.none()
+        # otherwise apply filters, query, sort, etc.
+        else:
+            search_opts = form.cleaned_data
+            sqs = sqs.order_by(self.solr_sort[search_opts['sort']])
+
+        self.queryset = sqs
+        return sqs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        self._form.set_choices_from_facets(self.object_list.get_facets()['facet_fields'])
+        return context
+
+    def get_page_labels(self, paginator):
+        '''generate labels for pagination'''
+        form = self.get_form()
+        # if invalid, should show 'N/A'
+        if not form.is_valid():
+            return [(1, 'N/A')]
+
+        # otherwise default to numbered pages for now
+        # NOTE could implement alpha here, but tougher for titles
+        return super().get_page_labels(paginator)
+        
     def get_absolute_url(self):
         '''Get the full URI of this page.'''
         return absolutize_url(reverse('books:books-list'))

--- a/mep/books/views.py
+++ b/mep/books/views.py
@@ -8,7 +8,7 @@ from mep.books.forms import ItemSearchForm
 from mep.books.models import Item
 from mep.books.queryset import ItemSolrQuerySet
 from mep.common import SCHEMA_ORG
-from mep.common.utils import absolutize_url, alpha_pagelabels
+from mep.common.utils import absolutize_url
 from mep.common.views import (AjaxTemplateMixin, FacetJSONMixin,
                               LabeledPagesMixin, RdfViewMixin)
 
@@ -65,7 +65,8 @@ class ItemList(LabeledPagesMixin, ListView, FormMixin, AjaxTemplateMixin, FacetJ
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        self._form.set_choices_from_facets(self.object_list.get_facets()['facet_fields'])
+        self._form.set_choices_from_facets(
+            self.object_list.get_facets()['facet_fields'])
         return context
 
     def get_page_labels(self, paginator):
@@ -78,7 +79,7 @@ class ItemList(LabeledPagesMixin, ListView, FormMixin, AjaxTemplateMixin, FacetJ
         # otherwise default to numbered pages for now
         # NOTE could implement alpha here, but tougher for titles
         return super().get_page_labels(paginator)
-        
+
     def get_absolute_url(self):
         '''Get the full URI of this page.'''
         return absolutize_url(reverse('books:books-list'))

--- a/mep/common/forms.py
+++ b/mep/common/forms.py
@@ -4,6 +4,46 @@ from django.core.validators import RegexValidator
 from django.utils.text import mark_safe
 
 
+class SelectDisabledMixin():
+    '''
+    Mixin for :class:`django.forms.RadioSelect` or :class:`django.forms.CheckboxSelect`
+    classes to set an option as disabled. To disable, the widget's choice
+    label option should be passed in as a dictionary with `disabled` set
+    to True::
+
+        {'label': 'option', 'disabled': True}.
+    '''
+
+    # Using a solution at https://djangosnippets.org/snippets/2453/
+    def create_option(self, name, value, label, selected, index, subindex=None,
+                      attrs=None):
+        disabled = None
+
+        if isinstance(label, dict):
+            label, disabled = label['label'], label.get('disabled', False)
+        option_dict = super().create_option(
+            name, value, label, selected, index,
+            subindex=subindex, attrs=attrs
+        )
+        if disabled:
+            option_dict['attrs'].update({'disabled': 'disabled'})
+        return option_dict
+
+
+class RadioSelectWithDisabled(SelectDisabledMixin, forms.RadioSelect):
+    '''
+    Subclass of :class:`django.forms.RadioSelect` with option to mark
+    a choice as disabled.
+    '''
+
+
+class SelectWithDisabled(SelectDisabledMixin, forms.Select):
+    '''
+    Subclass of :class:`django.forms.Select` with option to mark
+    a choice as disabled.
+    '''
+
+
 class CheckboxFieldset(forms.CheckboxSelectMultiple):
     '''Override of :class:`~django.forms.CheckboxSelectMultiple`
     that renders as a fieldset with checkbox inputs.'''

--- a/mep/common/templates/common/form_errors.html
+++ b/mep/common/templates/common/form_errors.html
@@ -1,0 +1,14 @@
+{# this template is included on search forms to display form errors. #}
+{% if form.errors %}
+<div role="alert" class="errors" aria-labelledby="errors" aria-live="polite">
+    <span id="errors">Errors:</span>
+    <ul>
+        {% for field, errors in form.errors.items %}
+        {# no clean way to get field labels here, so we just collapse the error lists #}
+        {% for error in errors %}
+            <li>{{ error }}</li>
+        {% endfor %}
+    {% endfor %}
+    </ul>
+</div>
+{% endif %}

--- a/mep/people/forms.py
+++ b/mep/people/forms.py
@@ -1,11 +1,9 @@
 from django import forms
 from django.template.loader import get_template
 
-from mep.common.forms import FacetChoiceField, FacetForm, CheckboxFieldset, \
-    RangeField, RangeWidget
-from django.core.cache import cache
+from mep.common.forms import (CheckboxFieldset, FacetChoiceField, FacetForm,
+                              RangeField, RangeWidget, SelectWithDisabled)
 from mep.people.models import Person
-from mep.people.queryset import PersonSolrQuerySet
 
 
 class PersonChoiceField(forms.ModelChoiceField):
@@ -33,49 +31,6 @@ class PersonMergeForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.fields['primary_person'].queryset = \
             Person.objects.filter(id__in=person_ids)
-
-
-## SelectDisabledMixin borrowed from ppa-django
-
-
-class SelectDisabledMixin(object):
-    '''
-    Mixin for :class:`django.forms.RadioSelect` or :class:`django.forms.CheckboxSelect`
-    classes to set an option as disabled. To disable, the widget's choice
-    label option should be passed in as a dictionary with `disabled` set
-    to True::
-
-        {'label': 'option', 'disabled': True}.
-    '''
-
-    # Using a solution at https://djangosnippets.org/snippets/2453/
-    def create_option(self, name, value, label, selected, index, subindex=None,
-                      attrs=None):
-        disabled = None
-
-        if isinstance(label, dict):
-            label, disabled = label['label'], label.get('disabled', False)
-        option_dict = super().create_option(
-            name, value, label, selected, index,
-            subindex=subindex, attrs=attrs
-        )
-        if disabled:
-            option_dict['attrs'].update({'disabled': 'disabled'})
-        return option_dict
-
-
-class RadioSelectWithDisabled(SelectDisabledMixin, forms.RadioSelect):
-    '''
-    Subclass of :class:`django.forms.RadioSelect` with option to mark
-    a choice as disabled.
-    '''
-
-
-class SelectWithDisabled(SelectDisabledMixin, forms.Select):
-    '''
-    Subclass of :class:`django.forms.Select` with option to mark
-    a choice as disabled.
-    '''
 
 
 class MemberSearchForm(FacetForm):

--- a/mep/people/geonames.py
+++ b/mep/people/geonames.py
@@ -19,7 +19,7 @@ class GeoNamesUnauthorized(GeoNamesError):
     '''GeoNames unauthorized response (raised when username is not set)'''
 
 
-class GeoNamesAPI(object):
+class GeoNamesAPI():
     '''Minimal wrapper around GeoNames API.  Currently supports simple
     searching by name and generating a uri from an id.  Expects
     **GEONAMES_USERNAME** to be configured in django settings.'''

--- a/mep/people/geonames.py
+++ b/mep/people/geonames.py
@@ -19,7 +19,7 @@ class GeoNamesUnauthorized(GeoNamesError):
     '''GeoNames unauthorized response (raised when username is not set)'''
 
 
-class GeoNamesAPI():
+class GeoNamesAPI:
     '''Minimal wrapper around GeoNames API.  Currently supports simple
     searching by name and generating a uri from an id.  Expects
     **GEONAMES_USERNAME** to be configured in django settings.'''
@@ -58,7 +58,7 @@ class GeoNamesAPI():
             return data
 
     def search(self, query, max_rows=None, feature_class=None,
-        feature_code=None, name_start=False):
+               feature_code=None, name_start=False):
         '''Search for places and return the list of results'''
         api_method = 'searchJSON'
 

--- a/mep/people/templates/people/member_list.html
+++ b/mep/people/templates/people/member_list.html
@@ -21,19 +21,7 @@
     <form id="members-form">
         {% render_field form.query %}
         <label for="{{ form.query.id_for_label }}"></label>
-        {% if form.errors %}
-        <div role="alert" class="errors" aria-labelledby="errors" aria-live="polite">
-            <span id="errors">Errors:</span>
-            <ul>
-                {% for field, errors in form.errors.items %}
-                {# no clean way to get field labels here, so we just collapse the error lists #}
-                {% for error in errors %}
-                    <li>{{ error }}</li>
-                {% endfor %}
-            {% endfor %}
-            </ul>
-        </div>
-        {% endif %}
+        {% include 'common/form_errors.html' %}
         <fieldset class="group">
             <legend>Filter by:</legend>
             <div class="inner">

--- a/mep/people/tests/test_forms.py
+++ b/mep/people/tests/test_forms.py
@@ -7,8 +7,8 @@ from django.template.defaultfilters import date as format_date
 
 from mep.accounts.models import Account, Subscription, Borrow
 from mep.books.models import Item
-from mep.people.forms import PersonChoiceField, PersonMergeForm, \
-    RadioSelectWithDisabled, MemberSearchForm
+from mep.common.forms import RadioSelectWithDisabled
+from mep.people.forms import PersonChoiceField, PersonMergeForm, MemberSearchForm
 from mep.people.models import Person
 
 

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -11,16 +11,14 @@ from django.views.generic import DetailView, ListView
 from django.views.generic.edit import FormMixin, FormView
 
 from mep.accounts.models import Event
-from mep.common.utils import alpha_pagelabels
+from mep.common import SCHEMA_ORG
+from mep.common.utils import absolutize_url, alpha_pagelabels
 from mep.common.views import (AjaxTemplateMixin, FacetJSONMixin,
                               LabeledPagesMixin, RdfViewMixin)
 from mep.people.forms import MemberSearchForm, PersonMergeForm
 from mep.people.geonames import GeoNamesAPI
 from mep.people.models import Country, Location, Person
 from mep.people.queryset import PersonSolrQuerySet
-
-from mep.common.utils import absolutize_url
-from mep.common import SCHEMA_ORG
 
 
 class MembersList(LabeledPagesMixin, ListView, FormMixin, AjaxTemplateMixin, FacetJSONMixin, RdfViewMixin):

--- a/srcmedia/ts/books-search.ts
+++ b/srcmedia/ts/books-search.ts
@@ -1,17 +1,121 @@
+import { merge } from 'rxjs'
+import { map, filter, mapTo, startWith, distinctUntilChanged, withLatestFrom, debounceTime } from 'rxjs/operators'
+
 import PageControls from './components/PageControls'
 import { RxSelect } from './lib/select'
+import { RxOutput } from './lib/output'
+import { RxFacetedSearchForm } from './lib/form'
+import { arraysAreEqual } from './lib/common'
 
 document.addEventListener('DOMContentLoaded', () => {
 
-    // selectors
+    /* ELEMENTS */
     const $booksSearchForm = document.getElementById('books-form') as HTMLFormElement
     const $pageControls = document.getElementsByClassName('sort-pages')[0] as HTMLElement
     const $pageSelect = document.querySelector('select[name=page]') as HTMLSelectElement
+    const $sortSelect = document.querySelector('select[name=sort]') as HTMLSelectElement
+    const $resultsOutput = document.querySelector('output.results') as HTMLOutputElement
+    const $totalResultsOutput = document.querySelector('output.total-results') as HTMLOutputElement
+    const $errors = document.querySelector('div[role=alert].errors')
 
-    // components
+    /* COMPONENTS */
+    const booksSearchForm = new RxFacetedSearchForm($booksSearchForm)
     const pageControls = new PageControls($pageControls)
     const pageSelect = new RxSelect($pageSelect)
+    const sortSelect = new RxSelect($sortSelect)
+    const resultsOutput = new RxOutput($resultsOutput)
+    const totalResultsOutput = new RxOutput($totalResultsOutput)
 
-    // bindings
-    pageSelect.value.subscribe(() => $booksSearchForm.submit()) // basic submission
+    /* OBSERVABLES */
+    const currentPage$ = pageSelect.value.pipe(
+        startWith(pageSelect.element.value), // start with the current page
+        map(p => parseInt(p)), // get a number from a string, for math
+        distinctUntilChanged() // only update when changed
+    )
+    const totalResults$ = booksSearchForm.totalResults.pipe(
+        map(t => parseInt(t)),
+    )
+    const totalPages$ = booksSearchForm.pageLabels.pipe(
+        map(l => l.length), // number of page labels tells us the number of pages
+        distinctUntilChanged()
+    )
+    const noResults$ = booksSearchForm.totalResults.pipe(
+        map(t => t === '0'), // true if totalResults is '0'
+        distinctUntilChanged()
+    )
+    const pageLabels$ = booksSearchForm.pageLabels.pipe(
+        startWith([...Array(pageSelect.element.options.length)].map((_, i) => {
+            return pageSelect.element.options[i].innerHTML // compare with the initial page labels
+        })),
+        distinctUntilChanged(arraysAreEqual),
+        filter(l => !arraysAreEqual(l, [""])) // ignore empty page labels
+    )
+    const noResultsPageOption$ = noResults$.pipe(
+        filter(n => n === true), // only generate if no results
+        mapTo([{ value: '1', text: 'N/A' }]) // create a 'N/A' page option
+    )
+    const pageLabelOptions$ = merge(
+        pageLabels$.pipe( // generate new <options> based on page labels if we have any
+            map(labels => labels.map((label, pageNumber) => ({
+                value: (pageNumber + 1).toString(), // <option> value is its index (page number)
+                text: label, // text is the page label
+            })))
+        ),
+        noResultsPageOption$ // if no results, use the 'N/A' label
+    )
+    const nextPage$ = pageControls.pageChanges.pipe(
+        withLatestFrom(currentPage$), // check the current page
+        map(([a, c]) => a === 'next' ? c + 1 : c - 1), // if 'next', add 1, otherwise subtract 1
+        map(c => c.toString()) // map to a string for passing as pageSelect value
+    )
+    const reloadResults$ = merge( // a list of all the things that require fetching new results (jump to page 1)
+        // reloadFacets$, // anything that changes facets also triggers new results
+        sortSelect.value
+    ).pipe(debounceTime(100))
+    const totalResultsText$ = merge(
+        totalResults$.pipe(map(t => `${t.toLocaleString()} total results`)), // when there are results, say how many, with a comma
+        reloadResults$.pipe(mapTo('Results are loading')) // when loading, replace with this text
+    )
+
+    /* SUBSCRIPTIONS */
+
+    // If there were errors, make sure they're cleared when the form becomes valid
+    if ($errors) {
+        booksSearchForm.valid.pipe(filter(v => v)).subscribe(() => {
+            $errors.remove() // NOTE could use a nicer animation here?
+        })
+    }
+
+    // Disable the page selection dropdown if there aren't any results
+    noResults$.subscribe(pageSelect.disabled)
+
+    // When we need new results, go back to page 1
+    reloadResults$.subscribe(() => pageSelect.value.next('1'))
+
+    // When the page is changed, submit the form and apply loading styles
+    pageSelect.value.subscribe(() => {
+        booksSearchForm.getResults()
+        pageControls.element.setAttribute('aria-busy', '') // empty string used for boolean attributes
+        resultsOutput.element.setAttribute('aria-busy', '')
+    })
+
+    // When next/previous page links are clicked, go to the next page
+    nextPage$.subscribe(pageSelect.value)
+
+    // When the page labels change, pass them to the page select to re-render options
+    pageLabelOptions$.subscribe(pageSelect.options)
+
+    // Keep the "total results" text updated
+    totalResultsText$.subscribe(totalResultsOutput.update)
+
+    // When results are loaded, remove loading styles and display the results
+    // Also update the next/prev buttons in case they become disabled
+    booksSearchForm.results.pipe(
+        withLatestFrom(currentPage$, totalPages$)
+    ).subscribe(([results, currentPage, totalPages]) => {
+        pageControls.update([currentPage, totalPages])
+        pageControls.element.removeAttribute('aria-busy')
+        resultsOutput.element.removeAttribute('aria-busy')
+        resultsOutput.update(results)
+    })
 })

--- a/srcmedia/ts/members-search.ts
+++ b/srcmedia/ts/members-search.ts
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const $membersSearchForm = document.getElementById('members-form') as HTMLFormElement
     const $keywordInput = document.querySelector('input[name=query]') as HTMLInputElement
     const $hasCardInput = document.querySelector('input[name=has_card]') as HTMLInputElement
-    const $resultsOutput = document.querySelector('output[form=members-form]') as HTMLOutputElement
+    const $resultsOutput = document.querySelector('output.results') as HTMLOutputElement
     const $totalResultsOutput = document.querySelector('output.total-results') as HTMLOutputElement
     const $pageSelect = document.querySelector('select[name=page]') as HTMLSelectElement
     const $sortSelect = document.querySelector('select[name=sort]') as HTMLSelectElement


### PR DESCRIPTION
this PR:
- moves a few form-related classes to `common/` since they're now used on two different forms
- creates a basic search form for books (for now just contains sort)
- updates the `ItemList` view to have the search form and return a `SolrQuerySet`
- updates the `item_list.html` template to include the form and render errors
- updates `books-search.ts` to add reactivity to the books search form
- adds new tests
- cleans up a few random pep8 things