### PR TITLE
setup google analytics (#360)

### DIFF
--- a/DEPLOYNOTES.rst
+++ b/DEPLOYNOTES.rst
@@ -3,6 +3,13 @@
 Deploy and Upgrade notes
 ========================
 
+0.22
+----
+
+* You must configure **GTAGS_ANALYTICS_ID** and **GTAGS_ANALYTICS_ENV** in
+  ``local_settings.py`` in order for Google Analytics to function. See the note
+  in ``local_settings.py.sample`` for more information.
+
 0.21
 ----
 

--- a/mep/context_processors.py
+++ b/mep/context_processors.py
@@ -6,7 +6,7 @@ def template_settings(request):
 
     context_extras = {
         'SHOW_TEST_WARNING': getattr(settings, 'SHOW_TEST_WARNING', False),
-        'GTAGS_ANALYTICS_ID': getattr(settings, 'GTAGS_ANALYTICS_ID', False),
-        'GTAGS_ANALYTICS_ENV': getattr(settings, 'GTAGS_ANALYTICS_ENV', False)
+        'GTAGS_ANALYTICS_ID': getattr(settings, 'GTAGS_ANALYTICS_ID', None),
+        'GTAGS_ANALYTICS_ENV': getattr(settings, 'GTAGS_ANALYTICS_ENV', None)
     }
     return context_extras

--- a/mep/context_processors.py
+++ b/mep/context_processors.py
@@ -6,6 +6,7 @@ def template_settings(request):
 
     context_extras = {
         'SHOW_TEST_WARNING': getattr(settings, 'SHOW_TEST_WARNING', False),
-        'INCLUDE_ANALYTICS': getattr(settings, 'INCLUDE_ANALYTICS', False)
+        'GTAGS_ANALYTICS_ID': getattr(settings, 'GTAGS_ANALYTICS_ID', False),
+        'GTAGS_ANALYTICS_ENV': getattr(settings, 'GTAGS_ANALYTICS_ENV', False)
     }
     return context_extras

--- a/mep/local_settings.py.sample
+++ b/mep/local_settings.py.sample
@@ -92,3 +92,12 @@ LOGGING = {
 
     },
 }
+
+# Google Analytics tracking ID
+# GTAGS_ANALYTICS_ID = ''
+
+# Google Analytics custom 'environment' dimension
+# used to separate production from QA sessions
+# use 'test' or 'qa' for QA and 'prod' or 'production' for production
+# https://support.google.com/analytics/answer/2709828
+# GTAGS_ANALYTICS_ENV = ''

--- a/srcmedia/ts/globals.d.ts
+++ b/srcmedia/ts/globals.d.ts
@@ -1,2 +1,2 @@
-// make tablesort available for import in typescript code
-declare module 'tablesort'
+declare module 'tablesort' // make tablesort available for import in typescript
+declare const gtag: Function // google analytics

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,10 @@
         <link rel="manifest" href="{% static 'favicon/site.webmanifest' %}" />
         <link rel="mask-icon" href="{% static 'favicon/safari-pinned-tab.svg' %}" color="#E9E9E9" />
         <meta name="theme-color" content="#ffffff" />
+        <!-- analytics -->
+        {% if not request.is_preview and GTAGS_ANALYTICS_ID %}
+            {% include 'snippets/analytics.html' %}
+        {% endif %}
         <!-- styles -->
         {% if SHOW_TEST_WARNING %}
         <link rel="stylesheet" type="text/css" href="{% static 'css/test-banner.css' %}">

--- a/templates/snippets/analytics.html
+++ b/templates/snippets/analytics.html
@@ -1,0 +1,14 @@
+{% load static %}
+{# google analytics tracking code #}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ GTAGS_ANALYTICS_ID }}"></script>
+<script nonce="{{ request.csp_nonce }}">
+    window.dataLayer = window.dataLayer || []
+    function gtag(){ dataLayer.push(arguments) }
+    gtag('js', new Date())
+    gtag('config', '{{ GTAGS_ANALYTICS_ID }}', {
+        'custom_map': {
+            'dimension1': 'env'
+        }
+    })
+    gtag('event', 'env_dimension', {'env': '{{ GTAGS_ANALYTICS_ENV }}'})
+</script>


### PR DESCRIPTION
not a whole lot going on here; mostly just setting up analytics according to [google's documentation](https://developers.google.com/analytics/devguides/collection/gtagjs). we use the newer `gtag.js` format.

adds new local settings values for the google analytics property ID, as well as for an "environment" variable that indicates to google whether the pageviews should be recorded as a production or qa environment. this lets us have separate views in google analytics for each environment (i've already configured this for S&Co) so we can test things like "did this click actually create a pageview?" without polluting the production analytics.

one new thing is the inclusion of the `nonce={{ request.csp_nonce }}` attribute on the script tag that starts up analytics. this will let us use the [script-src csp directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src) to prevent inline `<script>` tags but whitelist specific ones that we control, which is handy. the attribute isn't populated right now, but it will be once we [configure it in django-csp](https://django-csp.readthedocs.io/en/latest/nonce.html) as part of #361.