### PR TITLE
content security policy (#361)

### DIFF
--- a/mep/local_settings.py.sample
+++ b/mep/local_settings.py.sample
@@ -92,3 +92,12 @@ LOGGING = {
 
     },
 }
+
+# Content security policy controls - see `settings.py` for policy settings.
+# In development, set REPORT_ONLY to True.
+# In QA, set REPORT_ONLY to True and specify a "report-only" endpoint.
+# In production, set REPORT_ONLY to False and specify an "enforced" endpoint.
+# https://github.com/mozilla/django-csp
+#
+# CSP_REPORT_ONLY = False
+# CSP_REPORT_URI = ''

--- a/mep/local_settings.py.sample
+++ b/mep/local_settings.py.sample
@@ -94,10 +94,23 @@ LOGGING = {
 }
 
 # Content security policy controls - see `settings.py` for policy settings.
-# In development, set REPORT_ONLY to True.
-# In QA, set REPORT_ONLY to True and specify a "report-only" endpoint.
-# In production, set REPORT_ONLY to False and specify an "enforced" endpoint.
 # https://github.com/mozilla/django-csp
 #
-# CSP_REPORT_ONLY = False
-# CSP_REPORT_URI = ''
+# In development, set REPORT_ONLY to True and leave endpoint as localhost/. This
+# will log CSP violations to the browser console but not block or report them.
+#
+# In QA, set REPORT_ONLY to True and specify a "report-only" endpoint. This will
+# not block CSP violations, but will report them to an endpoint.
+#
+# In production, set REPORT_ONLY to False and specify an "enforced" endpoint.
+# This will both block and report CSP violations.
+#
+# CSP_REPORT_ONLY = True
+# CSP_REPORT_URI = 'localhost/'
+#
+# Uncomment the below lines to allow content to be served from webpack's dev
+# server through CSP controls when developing locally.
+#
+# CSP_STYLE_SRC += ("'unsafe-inline'",)
+# CSP_SCRIPT_SRC += ("'unsafe-inline'", "http://localhost:3000")
+# CSP_DEFAULT_SRC = ("http://localhost:3000", "ws://localhost:3000")

--- a/mep/settings.py
+++ b/mep/settings.py
@@ -76,6 +76,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
+    'csp.middleware.CSPMiddleware',
 ]
 
 AUTHENTICATION_BACKENDS = (
@@ -203,6 +204,30 @@ GRAPPELLI_INDEX_DASHBOARD = 'mep.dashboard.CustomIndexDashboard'
 
 # username for logging activity by local scripts
 SCRIPT_USERNAME = 'script'
+
+# django-csp configuration for content security policy definition and
+# violation reporting - https://github.com/mozilla/django-csp
+
+# fallback for all protocols: block it
+CSP_DEFAULT_SRC = "'none'"
+
+# allow loading js locally and from google (for analytics)
+CSP_SCRIPT_SRC = ("'self'", 'https://www.googletagmanager.com')
+
+# allow loading fonts locally only
+CSP_FONT_SRC = ("'self'",)
+
+# allow loading css locally only
+CSP_STYLE_SRC = ("'self'",)
+
+# allow loading local images and google tracking pixel
+CSP_IMG_SRC = ("'self'", 'https://www.google-analytics.com')
+
+# exclude admin and cms urls from csp directives since they're authenticated
+CSP_EXCLUDE_URL_PREFIXES = ('/admin', '/cms')
+
+# allow usage of nonce for inline js (for analytics)
+CSP_INCLUDE_NONCE_IN = ('script-src',)
 
 
 ##################

--- a/mep/settings.py
+++ b/mep/settings.py
@@ -220,6 +220,9 @@ CSP_FONT_SRC = ("'self'",)
 # allow loading css locally only
 CSP_STYLE_SRC = ("'self'",)
 
+# allow loading web manifest locally only
+CSP_MANIFEST_SRC = ("'self'",)
+
 # allow loading local images and google tracking pixel
 CSP_IMG_SRC = ("'self'", 'https://www.google-analytics.com')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ progressbar2
 rdflib
 rdflib-jsonld
 djiffy
+django-csp


### PR DESCRIPTION
- adds `django-csp` to dependencies
- adds a baseline security setup pared down from PPA's settings (we can adjust if we need to)
- adds new settings to sample local settings, including some explanation of how to configure based on environment and some convenience stuff for local development