### PR TITLE
style changes from Josh's notes

### DIFF
--- a/mep/common/templatetags/mep_tags.py
+++ b/mep/common/templatetags/mep_tags.py
@@ -1,4 +1,7 @@
+from urllib.parse import urlparse
+
 from django.template.defaulttags import register
+
 
 @register.filter
 def dict_item(dictionary, key):
@@ -8,3 +11,23 @@ def dict_item(dictionary, key):
         {{ mydict|dict_item:keyvar }}
     '''
     return dictionary.get(key, None)
+
+@register.filter
+def domain(url):
+    '''Template filter to extract the domain part of a link, for use in creating
+    link text automatically from a URL. Example use::
+
+        <a href="{{ url }}">{{ url|domain }}</a>
+
+    which could create something like::
+
+        <a href="http://en.wikipedia.org/">wikipedia</a>
+    
+    Note that this doesn't work on URLs without a // in them, following syntax
+    specified in RFC 1808 as implemented in Python's `urlparse`.
+    '''
+    try:
+        netloc_parts = urlparse(url).netloc.split('.')
+        return netloc_parts[-2] # piece right before the top-level domain
+    except:
+        return None

--- a/mep/common/templatetags/mep_tags.py
+++ b/mep/common/templatetags/mep_tags.py
@@ -29,5 +29,5 @@ def domain(url):
     try:
         netloc_parts = urlparse(url).netloc.split('.')
         return netloc_parts[-2] # piece right before the top-level domain
-    except (IndexError, ValueError): # parser fail or no domain portion
+    except (TypeError, IndexError, ValueError, AttributeError):
         return None

--- a/mep/common/templatetags/mep_tags.py
+++ b/mep/common/templatetags/mep_tags.py
@@ -29,5 +29,5 @@ def domain(url):
     try:
         netloc_parts = urlparse(url).netloc.split('.')
         return netloc_parts[-2] # piece right before the top-level domain
-    except:
+    except (IndexError, ValueError): # parser fail or no domain portion
         return None

--- a/mep/common/tests.py
+++ b/mep/common/tests.py
@@ -21,7 +21,7 @@ from mep.common.admin import LocalUserAdmin
 from mep.common.forms import CheckboxFieldset, FacetChoiceField, FacetForm, \
     RangeField, RangeWidget
 from mep.common.models import AliasIntegerField, DateRange, Named, Notable
-from mep.common.templatetags.mep_tags import dict_item
+from mep.common.templatetags.mep_tags import dict_item, domain
 from mep.common.utils import absolutize_url, alpha_pagelabels
 from mep.common.validators import verify_latlon
 from mep.common.views import AjaxTemplateMixin, FacetJSONMixin, \
@@ -348,6 +348,19 @@ class TestTemplateTags(TestCase):
         assert dict_item({13: 'lucky'}, 13) == 'lucky'
         # integer value
         assert dict_item({13: 7}, 13) == 7
+
+
+    def test_domain(self):
+        # works correctly on URLs that have both a domain and //
+        assert domain('https://docs.python.org/3/library/') == 'python'
+        assert domain('//www.cwi.nl:80/%7Eguido/Python.html') == 'cwi'
+        # returns None on local URLs or those missing //
+        assert domain('www.cwi.nl/%7Eguido/Python.html') is None
+        assert domain('help/Python.html') is None
+        # returns None on garbage
+        assert domain('oops') is None
+        assert domain(2) is None
+        assert domain(None) is None
 
 
 class TestCheckboxFieldset(TestCase):

--- a/mep/people/forms.py
+++ b/mep/people/forms.py
@@ -66,7 +66,7 @@ class MemberSearchForm(FacetForm):
     }))
     membership_dates = RangeField(label='Membership Dates', required=False,
         widget=RangeWidget(attrs={'size': 4}))
-    birth_year = RangeField(required=False,
+    birth_year = RangeField(label='Birth Year', required=False,
         widget=RangeWidget(attrs={'size': 4}))
 
     def set_range_minmax(self, range_minmax):

--- a/mep/people/templates/people/member_list.html
+++ b/mep/people/templates/people/member_list.html
@@ -25,13 +25,13 @@
         <fieldset class="group">
             <legend>Filter by:</legend>
             <div class="inner">
-                <fieldset class="range facet {{ form.membership_dates.css_classes }}" id="id_{{ form.membership_dates.name }}">
-                    <legend>{{ form.membership_dates.label }}</legend>
-                    {{ form.membership_dates }}
-                </fieldset>
                 <fieldset class="range facet {{ form.birth_year.css_classes }}" id="id_{{ form.birth_year.name }}">
                     <legend>{{ form.birth_year.label }}</legend>
                     {{ form.birth_year }}
+                </fieldset>
+                <fieldset class="range facet {{ form.membership_dates.css_classes }}" id="id_{{ form.membership_dates.name }}">
+                    <legend>{{ form.membership_dates.label }}</legend>
+                    {{ form.membership_dates }}
                 </fieldset>
                 {% render_field form.has_card class+="sr-only" tabindex=0 %}
                 <label for="{{ form.has_card.id_for_label }}">

--- a/mep/people/templates/people/snippets/member_result.html
+++ b/mep/people/templates/people/snippets/member_result.html
@@ -25,7 +25,7 @@
             {% endif %}
             {% if member.urls.count > 0 %}
                 {% for reference in member.urls.all %}
-                <dd><a href="{{ reference }}">more info</a></dd>
+                <dd><a href="{{ reference }}">{{ reference.url|domain|capfirst }}</a></dd>
                 {% endfor %}
             {% endif %}
         </div>

--- a/srcmedia/scss/common/_footer.scss
+++ b/srcmedia/scss/common/_footer.scss
@@ -15,6 +15,10 @@
         font-size: .6rem;
     }
 
+    .pending::after {
+        content: '*';
+    }
+
     a {
         transition: color 0.2s;
 
@@ -42,7 +46,8 @@
             padding-bottom: .2rem;
         }
 
-        a {
+        a,
+        span {
             text-transform: uppercase;
         }
     }
@@ -91,6 +96,22 @@
         span {
             display: inline-block;
             flex: auto;
+        }
+
+        .note {
+            flex: none;
+            width: 100%;
+            margin-bottom: 0.5rem;
+
+            &::before {
+                content: '*';
+            }
+
+            @media (min-width: $breakpoint-s) {
+                flex: auto;
+                width: fit-content;
+                margin-bottom: 0;
+            }
         }
 
         #a11y {

--- a/srcmedia/scss/common/_header.scss
+++ b/srcmedia/scss/common/_header.scss
@@ -169,17 +169,25 @@
 
     .logotype {
         display: block;
-        width: $breakpoint-xs;
+        width: 100%;
         padding-top: 4rem;
 
+        @media (min-width: 460px) and (max-width: $breakpoint-s) {
+            width: 460px;
+        }
+
         @media (min-width: $breakpoint-s) {
-            padding-top: 8rem;
-            width: 22rem;
+            padding-top: calc(10rem - 5%);
+            width: 65%;
         }
 
         @media (min-width: $breakpoint-l) {
             padding-top: 12rem;
-            width: 41rem;
+            width: 60%;
+        }
+
+        @media (min-width: $breakpoint-xl) {
+            width: 58rem;
         }
     }
 
@@ -190,12 +198,20 @@
         font-style: italic;
         font-size: 0.8rem;
         max-width: 10rem;
-        padding-top: 2rem;
+        padding-top: 1rem;
         padding-bottom: 8.5rem;
+
+        @media (min-width: 460px) and (max-width: $breakpoint-s) {
+            padding-top: 0.5rem;
+        }
 
         @media (min-width: $breakpoint-s) {
             padding-top: 0;
             max-width: none;
+        }
+
+        @media (min-width: $breakpoint-m) {
+            font-size: 1rem;
         }
 
         @media (min-width: $breakpoint-l) {
@@ -211,8 +227,16 @@
             bottom: 10rem;
         }
 
+        @media (min-width: $breakpoint-m) {
+            bottom: 7rem;
+        }
+
         @media (min-width: $breakpoint-l) {
             bottom: 16rem;
+        }
+
+        @media (min-width: $breakpoint-xl) {
+            bottom: 14rem;
         }
     }
 }

--- a/srcmedia/scss/common/_nav.scss
+++ b/srcmedia/scss/common/_nav.scss
@@ -118,14 +118,18 @@
             }
         }
 
-        .pending * {
+        .pending *,
+        .note {
             color: $mid-grey;
-            cursor: default;
+        }
+
+        .pending .title::after {
+            content: '*';
+            position: absolute;
         }
 
         .title,
-        .subtitle,
-        .note {
+        .subtitle {
             display: block;
         }
 
@@ -139,23 +143,19 @@
             }
         }
 
-        .subtitle,
+        .subtitle {
+            font-size: 0.7rem;
+            line-height: normal;
+            padding-top: .5rem;
+        }
+
         .note {
             font-size: 0.7rem;
             line-height: normal;
-        }
 
-        .pending .title::after,
-        .note::before {
-            content: '*';
-        }
-
-        .pending .title::after {
-            position: absolute;
-        }
-
-        .subtitle {
-            padding-top: .5rem;
+            &::before {
+                content: '*';
+            }
         }
     }
 }

--- a/srcmedia/scss/common/_nav.scss
+++ b/srcmedia/scss/common/_nav.scss
@@ -118,8 +118,14 @@
             }
         }
 
+        .pending * {
+            color: $mid-grey;
+            cursor: default;
+        }
+
         .title,
-        .subtitle {
+        .subtitle,
+        .note {
             display: block;
         }
 
@@ -133,9 +139,22 @@
             }
         }
 
-        .subtitle {
+        .subtitle,
+        .note {
             font-size: 0.7rem;
             line-height: normal;
+        }
+
+        .pending .title::after,
+        .note::before {
+            content: '*';
+        }
+
+        .pending .title::after {
+            position: absolute;
+        }
+
+        .subtitle {
             padding-top: .5rem;
         }
     }

--- a/templates/snippets/footer.html
+++ b/templates/snippets/footer.html
@@ -2,10 +2,10 @@
 <footer id="page-footer">
     <nav aria-label="footer navigation">
         <ul class="primary" aria-label="primary navigation">
-            <li><a href="{% url 'people:members-list' %}">members</a><li>
-            <li><a>lending library cards</a><li>
-            <li><a>books</a><li>
-            <li><a>analysis</a><li>
+            <li><span class="pending">members</span><li>
+            <li><span class="pending">books</span><li>
+            <li><span class="pending">cards</span><li>
+            <li><span class="pending">analysis</span><li>
             <li><a href="{% slugurl 'sources' %}">sources</a><li>
             <li><a href="{% slugurl 'about' %}">about</a><li>
         </ul>
@@ -28,6 +28,7 @@
         </a>
     </div>
     <div class="links">
+        <span class="note">Coming soon.</span>
         <a href="https://accessibility.princeton.edu/" id="a11y">Accessibility</a>
         <a href="https://accessibility.princeton.edu/accessibility-assistance" id="a11y-assist">Accessibility Assistance</a>
         <span id="copyright">&copy;{% now 'Y' %} Trustees of Princeton University</span>

--- a/templates/snippets/header.html
+++ b/templates/snippets/header.html
@@ -2,7 +2,7 @@
 <header id="page-header"{% if style %} class="{{ style }}"{% endif %}>
     <img class="bookmark" src="{% static 'img/headers/header-bookmark.svg' %}" alt="" hidden>
     {% if title %}<h1>{{ title }}</h1>{% endif %}
-    <img class="logotype" src="{% static 'img/logo/SCo_logo_text.png' %}" alt="shakespeare & company" hidden>
+    <img class="logotype" src="{% static 'img/logo/SCo_logo_text.svg' %}" alt="Shakespeare & Company" hidden>
     <p class="tagline" hidden>Recreating the world of the Lost Generation in interwar Paris.</p>
     <img class="chevron" src="{% static 'img/icons/chevron_down.png' %}" alt="" hidden>
 </header>

--- a/templates/snippets/nav.html
+++ b/templates/snippets/nav.html
@@ -19,31 +19,27 @@
             </a>
         </li>
         <li class="pending">
-            <a href="{% url 'people:members-list' %}">
+            <div>
                 <span class="title">members</span>
                 <span class="subtitle">Explore the lending library membership.</span>
-                <span class="note">Coming in 2019.</span>
-            </a>
+            </div>
         </li>
         <li class="pending">
-            <a href="{% url 'books:books-list' %}">
+            <div>
                 <span class="title">books</span>
                 <span class="subtitle">Explore the lending library holdings.</span>
-                <span class="note">Coming in 2019.</span>
-            </a>
+            </div>
         </li>
         <li class="pending">
             <div>
                 <span class="title">cards</span>
                 <span class="subtitle">Explore the extant lending library cards.</span>
-                <span class="note">Coming in 2019.</span>
             </div>
         </li>
         <li class="pending">
             <div>
                 <span class="title">analysis</span>
                 <span class="subtitle">Analyze the Shakespeare and Company community.</span>
-                <span class="note">Coming in 2019.</span>
             </div>
         </li>
         <li>
@@ -57,6 +53,7 @@
                 <span class="title">about</span>
                 <span class="subtitle">Learn about the Shakespeare and Company Project.</span>
             </a>
+            <span class="note">Coming soon.</span>
         </li>
     </ul>
 </nav>

--- a/templates/snippets/nav.html
+++ b/templates/snippets/nav.html
@@ -33,7 +33,7 @@
         <li class="pending">
             <div>
                 <span class="title">cards</span>
-                <span class="subtitle">Explore the extant lending library cards.</span>
+                <span class="subtitle">Explore the lending library cards.</span>
             </div>
         </li>
         <li class="pending">

--- a/templates/snippets/nav.html
+++ b/templates/snippets/nav.html
@@ -18,29 +18,33 @@
                 <img src="{% static 'img/icons/Delete.svg' %}" alt="Close main menu">
             </a>
         </li>
-        <li>
+        <li class="pending">
             <a href="{% url 'people:members-list' %}">
                 <span class="title">members</span>
                 <span class="subtitle">Explore the lending library membership.</span>
+                <span class="note">Coming in 2019.</span>
             </a>
         </li>
-        <li>
-            <a href="/cards">
-                <span class="title">cards</span>
-                <span class="subtitle">Explore the extant lending library cards.</span>
-            </a>
-        </li>
-        <li>
-            <a href="/books">
+        <li class="pending">
+            <a href="{% url 'books:books-list' %}">
                 <span class="title">books</span>
                 <span class="subtitle">Explore the lending library holdings.</span>
+                <span class="note">Coming in 2019.</span>
             </a>
         </li>
-        <li>
-            <a href="/analysis">
+        <li class="pending">
+            <div>
+                <span class="title">cards</span>
+                <span class="subtitle">Explore the extant lending library cards.</span>
+                <span class="note">Coming in 2019.</span>
+            </div>
+        </li>
+        <li class="pending">
+            <div>
                 <span class="title">analysis</span>
                 <span class="subtitle">Analyze the Shakespeare and Company community.</span>
-            </a>
+                <span class="note">Coming in 2019.</span>
+            </div>
         </li>
         <li>
             <a href="{% slugurl 'sources' %}">


### PR DESCRIPTION
this is notable in that it adds a very small template filter to extract the main domain portion of a link for display on member detail pages, so links like `en.wikipedia.org` will appear as `Wikipedia`. I wanted something a little smarter than "More info", and it seems to work OK for the rare cases where someone has links that aren't VIAF or Wikipedia (for example, princeton finding aids show "Princeton").

also covers #367 .