### PR TITLE
Filter members by nationality #195

### DIFF
--- a/DEPLOYNOTES.rst
+++ b/DEPLOYNOTES.rst
@@ -4,6 +4,14 @@ Deploy and Upgrade notes
 ========================
 
 
+0.22
+----
+
+* Solr schema has been changed and should be updated::
+
+  python manage.py solr_schema
+
+
 0.21
 ----
 

--- a/DEPLOYNOTES.rst
+++ b/DEPLOYNOTES.rst
@@ -7,9 +7,11 @@ Deploy and Upgrade notes
 0.22
 ----
 
-* Solr schema has been changed and should be updated::
+* Member search filter on nationality requires a Solr schema update
+  and reindex::
 
   python manage.py solr_schema
+  python manage.py index -i person
 
 
 0.21

--- a/mep/common/solr.py
+++ b/mep/common/solr.py
@@ -6,4 +6,6 @@ class SolrSchema(schema.SolrSchema):
 
     item_type = schema.SolrStringField()
 
+    nationality = schema.SolrStringField(multivalued=True)
+
     # relying on dynamic fields for now

--- a/mep/common/templates/common/widgets/checkbox_fieldset.html
+++ b/mep/common/templates/common/widgets/checkbox_fieldset.html
@@ -3,17 +3,20 @@ Template for CheckboxFieldset widget to render facet choices
 as a list of checkbox inputs, grouped in a fieldset and labeled
 with a legend.
 {% endcomment %}
+{% load mep_tags %}
 <fieldset {% include "django/forms/widgets/attrs.html" %}>
 <legend>{{ widget.legend }}</legend>
 <ul class="choices">
+{% with widget.attrs|dict_item:'data-hide-threshold' as hide_threshold %}
 {% for group, options, index in widget.optgroups %}
     {% for option in options %}
-    <li class="choice">
+    <li class="choice{% if facet_counts|dict_item:option.value <= hide_threshold %} hide{% endif %}">
         {# includes a revised version of Django's attr snippet to remove legend #}
         <input type="checkbox" value="{{ option.value }}" id="{{ option.attrs.id }}" name="{{ widget.name }}" {% if widget.required %}required{% endif %} {% if option.attrs.checked %}checked{% endif %}>
         <label for="{{ option.attrs.id }}"> {{ option.label }} </label>
     </li>
     {% endfor %}
 {% endfor %}
+{% endwith %}
 </ul>
 </fieldset>

--- a/mep/common/tests.py
+++ b/mep/common/tests.py
@@ -362,8 +362,10 @@ class TestCheckboxFieldset(TestCase):
     def test_get_context(self):
         checkbox_fieldset = CheckboxFieldset()
         checkbox_fieldset.legend = 'Test Legend'
+        checkbox_fieldset.facet_counts = {'value': 10}
         context = checkbox_fieldset.get_context('a name', ['a', 'b', 'c'], {})
         assert context['widget']['legend'] == 'Test Legend'
+        assert context['facet_counts'] == checkbox_fieldset.facet_counts
 
     def test_render(self):
 
@@ -424,6 +426,15 @@ class TestCheckboxFieldset(TestCase):
         checkbox_fieldset.is_required = True
         out = checkbox_fieldset.render('foo', 'bar')
         assert out.count('required') == 2
+
+        checkbox_fieldset.attrs['data-hide-threshold'] = 0
+        checkbox_fieldset.facet_counts = {'a': 0, 'b': 2}
+        output = checkbox_fieldset.render('sex', 'bar')
+        assert 'data-hide-threshold="0"' in output
+        # a choice should be hidden
+        assert '<li class="choice hide">' in output
+        # b choice should not be hidden
+        assert '<li class="choice">' in output
 
 
 class TestFacetField(TestCase):

--- a/mep/people/forms.py
+++ b/mep/people/forms.py
@@ -41,7 +41,6 @@ class MemberSearchForm(FacetForm):
         ('name', 'Name A-Z'),
     ]
 
-
     # NOTE these are not set by default!
     error_css_class = 'error'
     required_css_class = 'required'
@@ -65,9 +64,15 @@ class MemberSearchForm(FacetForm):
         'class': 'choice facet'
     }))
     membership_dates = RangeField(label='Membership Dates', required=False,
-        widget=RangeWidget(attrs={'size': 4}))
+                                  widget=RangeWidget(attrs={'size': 4}))
     birth_year = RangeField(label='Birth Year', required=False,
-        widget=RangeWidget(attrs={'size': 4}))
+                            widget=RangeWidget(attrs={'size': 4}))
+    nationality = FacetChoiceField(
+        label='Nationality', hide_threshold=0,
+        widget=CheckboxFieldset(attrs={
+            'class': 'choice facet'
+        })
+    )
 
     def set_range_minmax(self, range_minmax):
         '''Set the min, max, and placeholder values for all

--- a/mep/people/models.py
+++ b/mep/people/models.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.apps import apps
-from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
+from django.core.exceptions import MultipleObjectsReturned
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models, transaction
 from django.urls import reverse
@@ -433,7 +433,9 @@ class Person(Notable, DateRange, Indexable):
             'sort_name_sort_s': self.sort_name,
             'birth_year_i': self.birth_year,
             'death_year_i': self.death_year,
-            'has_card_b': self.has_card()
+            'has_card_b': self.has_card(),
+            'nationality': list(self.nationalities.all()
+                                    .values_list('name', flat=True))
         })
 
         # conditionally set fields that are not always present
@@ -448,7 +450,7 @@ class Person(Notable, DateRange, Indexable):
                 # use min and max because set order is not guaranteed
                 'account_start_i': min(account_years),
                 'account_end_i': max(account_years),
-                })
+            })
         if self.sex:
             index_data['sex_s'] = self.get_sex_display()
         return index_data

--- a/mep/people/templates/people/member_list.html
+++ b/mep/people/templates/people/member_list.html
@@ -40,6 +40,7 @@
                         aria-label="{{ form.has_card.help_text }}" tabindex=0 onclick="event.preventDefault()"/>
                 </label>
             {% render_field form.sex %}
+            {% render_field form.nationality %}
             </div>
             <input type="submit" value="submit"/>
         </fieldset>

--- a/mep/people/tests/test_models.py
+++ b/mep/people/tests/test_models.py
@@ -6,8 +6,7 @@ from unittest.mock import patch
 import pytest
 from django.urls import reverse
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import (MultipleObjectsReturned,
-                                    ObjectDoesNotExist, ValidationError)
+from django.core.exceptions import MultipleObjectsReturned, ValidationError
 from django.test import TestCase
 from django.urls import resolve
 from django.utils import timezone
@@ -237,13 +236,11 @@ class TestPerson(TestCase):
         subs.delete()
         assert pers.in_logbooks()
 
-
     def test_admin_url(self):
         pers = Person.objects.create(name='John')
         resolved_url = resolve(pers.admin_url())
         assert resolved_url.args[0] == str(pers.id)
         assert resolved_url.view_name == 'admin:people_person_change'
-
 
     def test_has_card(self):
         # create test person & account and associate them
@@ -257,9 +254,10 @@ class TestPerson(TestCase):
         assert not pers.has_card()
 
         # create card and add to account
-        src_type = SourceType.objects.get_or_create(name='Lending Library Card')[0]
-        card = Bibliography.objects.create(bibliographic_note='John\'s Library Card',
-            source_type=src_type)
+        src_type = SourceType.objects.get_or_create(
+            name='Lending Library Card')[0]
+        card = Bibliography.objects.create(
+            bibliographic_note='John\'s Library Card', source_type=src_type)
         acct.card = card
         acct.save()
         assert pers.has_card()
@@ -300,6 +298,8 @@ class TestPerson(TestCase):
         for missing_val in ['account_start_i', 'account_end_i',
                             'account_years_i', 'sex_s']:
             assert missing_val not in index_data
+        # nationality should be empty list
+        assert index_data['nationality'] == []
 
         # add account events for earliest/latest
         Subscription.objects.create(account=acct,
@@ -313,6 +313,19 @@ class TestPerson(TestCase):
         assert index_data['account_end_i'] == 1922
         assert index_data['account_years_is'] == [1921, 1922]
         assert index_data['sex_s'] == 'Male'
+
+        # add nationality
+        uk = Country.objects.create(
+            name='United Kingdom', code='UK',
+            geonames_id='http://sws.geonames.org/2635167/')
+        denmark = Country.objects.create(
+            name='Denmark', code='DK',
+            geonames_id='http://sws.geonames.org/2623032/')
+        pers.nationalities.add(uk)
+        pers.nationalities.add(denmark)
+        index_data = pers.index_data()
+        assert uk.name in index_data['nationality']
+        assert denmark.name in index_data['nationality']
 
 
 class TestPersonQuerySet(TestCase):

--- a/mep/people/tests/test_views.py
+++ b/mep/people/tests/test_views.py
@@ -582,11 +582,14 @@ class TestMembersListView(TestCase):
         # so add some before indexing in Solr
         card_member = Person.objects.filter(account__isnull=False).first()
         account = card_member.account_set.first()
-        Subscription.objects.create(account=account, start_date=date(1942, 3, 4))
-        Subscription.objects.create(account=account, end_date=date(1950, 1, 1))
+        Subscription.objects.create(
+            account=account, start_date=date(1942, 3, 4))
+        Subscription.objects.create(
+            account=account, end_date=date(1950, 1, 1))
 
         # create card and add to account
-        src_type = SourceType.objects.get_or_create(name='Lending Library Card')[0]
+        src_type = SourceType.objects.get_or_create(
+            name='Lending Library Card')[0]
         card = Bibliography.objects.create(bibliographic_note='A Library Card',
                                            source_type=src_type)
         account.card = card
@@ -598,8 +601,9 @@ class TestMembersListView(TestCase):
 
         # filter form should be displayed with filled-in query field one time
         self.assertContains(response, 'Search member', count=1)
-        # it should also have a card filter with a card count (check via card count)
-        self.assertContains(response, '<span class="count">1</span>', count=1)
+        # + card filter with a card count (1)
+        # + counts for nationality filter (2)
+        self.assertContains(response, '<span class="count">1</span>', count=3)
         # the filter should have a card image (counted later with other result
         # card icon) and it should have a tooltip
         self.assertContains(response, 'role="tooltip"', count=1)

--- a/mep/people/tests/test_views.py
+++ b/mep/people/tests/test_views.py
@@ -651,7 +651,7 @@ class TestMembersListView(TestCase):
         # should not display relevance score
         # NOTE: TEMPORARILY DISABLED while view requires login
         # self.assertNotContains(response, '<dt>relevance</dt>',
-            # msg_prefix='relevance score not displayed to anonymous user')
+        #     msg_prefix='relevance score not displayed to anonymous user')
 
         # sanity check date filters -- exclude the member with events
         response = self.client.get(self.members_url, {'membership_dates_0': 1951})
@@ -825,13 +825,17 @@ class TestMembersListView(TestCase):
         # faceting should be turned on via call to facet_fields twice
         mock_qs.facet_field.assert_any_call('has_card')
         mock_qs.facet_field.assert_any_call('sex', missing=True, exclude='sex')
+        mock_qs.facet_field.assert_any_call('nationality', exclude='nationality',
+                                            sort='value')
         # search and raw query not called without keyword search term
         mock_qs.search.assert_not_called()
         mock_qs.raw_query_parameters.assert_not_called()
         # should sort by solr field corresponding to default sort
-        mock_qs.order_by.assert_called_with(view.solr_sort[view.initial['sort']])
+        mock_qs.order_by.assert_called_with(
+            view.solr_sort[view.initial['sort']])
 
-        # enable card and sex filter, also test that a blank query doesn't force relevance
+        # enable card and sex filter, also test that a blank query doesn't
+        # force relevance
         view.request = self.factory.get(self.members_url, {
             'has_card': True,
             'query': '',
@@ -842,7 +846,8 @@ class TestMembersListView(TestCase):
         sqs = view.get_queryset()
         assert view.queryset == sqs
         # blank query left default sort in place too
-        mock_qs.order_by.assert_called_with(view.solr_sort[view.initial['sort']])
+        mock_qs.order_by.assert_called_with(
+            view.solr_sort[view.initial['sort']])
         # faceting should be on for both fields
         # and filtering by has card and sex, which should be tagged for
         # exclusion in calculating facets
@@ -876,6 +881,16 @@ class TestMembersListView(TestCase):
         del view._form
         sqs = view.get_queryset()
         mock_qs.filter.assert_any_call(account_years__range=(1919, 1923))
+
+        # filter on nationality
+        view.request = self.factory.get(self.members_url, {
+            'query': '',
+            'nationality': ['France']
+        })
+        del view._form
+        sqs = view.get_queryset()
+        mock_qs.filter.assert_any_call(nationality__in=['"France"'],
+                                       tag='nationality')
 
     def test_invalid_form(self):
         # make an invalid range request

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -119,8 +119,10 @@ class MembersList(LoginRequiredOr404Mixin, LabeledPagesMixin, ListView,
     }
 
     def get_queryset(self):
-        sqs = PersonSolrQuerySet().facet_field('has_card')\
-                                  .facet_field('sex', missing=True, exclude='sex')
+        sqs = PersonSolrQuerySet() \
+            .facet_field('has_card') \
+            .facet_field('sex', missing=True, exclude='sex') \
+            .facet_field('nationality', exclude='nationality', sort='value')
 
         form = self.get_form()
 
@@ -141,6 +143,10 @@ class MembersList(LoginRequiredOr404Mixin, LabeledPagesMixin, ListView,
                 sqs = sqs.filter(has_card=search_opts['has_card'])
             if search_opts['sex']:
                 sqs = sqs.filter(sex__in=search_opts['sex'], tag='sex')
+            if search_opts['nationality']:
+                sqs = sqs.filter(nationality__in=[
+                    '"%s"' % val for val in search_opts['nationality']
+                ], tag='nationality')
 
             # range filter by membership dates, if set
             if search_opts['membership_dates']:

--- a/srcmedia/scss/common/_forms.scss
+++ b/srcmedia/scss/common/_forms.scss
@@ -46,3 +46,7 @@ input[type=submit] {
 .no-js input[type=submit] {
     display: inline;
 }
+
+.choice.hide {
+    display: none;
+}

--- a/srcmedia/ts/members-search.ts
+++ b/srcmedia/ts/members-search.ts
@@ -7,7 +7,7 @@ import { RxOutput } from './lib/output'
 import { RxFacetedSearchForm } from './lib/form'
 import { RxSelect } from './lib/select'
 import PageControls from './components/PageControls'
-import { RxChoiceFacet, RxBooleanFacet } from './lib/facet'
+import { RxChoiceFacet, RxBooleanFacet, RxTextFacet } from './lib/facet'
 import { RxRangeFilter, rangesAreEqual } from './lib/filter'
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -39,7 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const genderFacet = new RxChoiceFacet($genderFacet)
     const memDateFacet = new RxRangeFilter($memDateFacet)
     const birthDateFacet = new RxRangeFilter($birthDateFacet)
-    const nationalityFacet = new RxChoiceFacet($nationalityFacet)
+    const nationalityFacet = new RxTextFacet($nationalityFacet)
 
     /* OBSERVABLES */
     const currentPage$ = pageSelect.value.pipe(

--- a/srcmedia/ts/members-search.ts
+++ b/srcmedia/ts/members-search.ts
@@ -24,6 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const $genderFacet = document.querySelector('#id_sex') as HTMLFieldSetElement
     const $memDateFacet = document.querySelector('#id_membership_dates') as HTMLFieldSetElement
     const $birthDateFacet = document.querySelector('#id_birth_year') as HTMLFieldSetElement
+    const $nationalityFacet = document.querySelector('#id_nationality') as HTMLFieldSetElement
     const $errors = document.querySelector('div[role=alert].errors')
 
     /* COMPONENTS */
@@ -38,6 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const genderFacet = new RxChoiceFacet($genderFacet)
     const memDateFacet = new RxRangeFilter($memDateFacet)
     const birthDateFacet = new RxRangeFilter($birthDateFacet)
+    const nationalityFacet = new RxChoiceFacet($nationalityFacet)
 
     /* OBSERVABLES */
     const currentPage$ = pageSelect.value.pipe(
@@ -119,6 +121,7 @@ document.addEventListener('DOMContentLoaded', () => {
         birthdateChange$,
         hasCardFacet.checked$.pipe(skip(1)), // ignore initial
         genderFacet.events,
+        nationalityFacet.events,
     )
     const reloadResults$ = merge( // a list of all the things that require fetching new results (jump to page 1)
         reloadFacets$, // anything that changes facets also triggers new results
@@ -143,6 +146,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const genderChoices = membersSearchForm.facets.pipe(
         pluck('facet_fields'),
         pluck('sex'),
+        flatMap(Object.entries),
+    )
+    const nationalityChoices = membersSearchForm.facets.pipe(
+        pluck('facet_fields'),
+        pluck('nationality'),
         flatMap(Object.entries),
     )
 
@@ -180,6 +188,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Update the gender facet
     genderChoices.subscribe(genderFacet.counts)
+
+    // Update the nationality facet
+    nationalityChoices.subscribe(nationalityFacet.counts)
 
     // When a user changes the form, get new facets
     reloadFacets$.subscribe(() => membersSearchForm.getFacets())


### PR DESCRIPTION
- adds a solr schema field for nationality facet (multi-value string)
- include nationality in person index data
- revise facet field widget & template to add an optional hide threshold and hide facet choices based on that threshold; hides zero count facets
- display the nationality form field to the members list template
- add view logic to get nationality facet counts and filter on nationality if set
- wire in nationality form filter to reactive form following the model of sex/gender filter

Testing requires updating solr schema and reindexing people.

Reactive form does not yet update show/hide logic when the counts change.