### PR TITLE
Feature/member cards

### DIFF
--- a/mep/accounts/models.py
+++ b/mep/accounts/models.py
@@ -387,7 +387,7 @@ class Event(Notable, PartialDateMixin):
         help_text='Edition of the work, if known.',
         on_delete=models.deletion.SET_NULL)
 
-    event_footnotes = GenericRelation(Footnote)
+    event_footnotes = GenericRelation(Footnote, related_query_name='events')
 
     objects = EventQuerySet.as_manager()
 
@@ -586,10 +586,11 @@ class Borrow(Event):
         (ITEM_BOUGHT, 'Bought'),
         (ITEM_MISSING, 'Missing'),
     )
-    item_status = models.CharField(max_length=2, blank=True,
+    item_status = models.CharField(
+        max_length=2, blank=True,
         help_text='Status of borrowed item (bought, missing, returned)',
         choices=STATUS_CHOICES)
-    footnotes = GenericRelation(Footnote)
+    footnotes = GenericRelation(Footnote, related_query_name='borrows')
 
     def save(self, *args, **kwargs):
         # if end date is set and item status is not, automatically set
@@ -602,8 +603,8 @@ class Borrow(Event):
 class Purchase(CurrencyMixin, Event):
     '''Inherited table indicating purchase events; extends :class:`Event`'''
     price = models.DecimalField(max_digits=8, decimal_places=2,
-        blank=True, null=True)
-    footnotes = GenericRelation(Footnote)
+                                blank=True, null=True)
+    footnotes = GenericRelation(Footnote, related_query_name='purchases')
 
     def date(self):
         '''alias of :attr:`date_range` for display; since reimbersument

--- a/mep/accounts/partial_date.py
+++ b/mep/accounts/partial_date.py
@@ -28,7 +28,7 @@ class DatePrecisionField(models.PositiveSmallIntegerField):
         return self.to_python(value)
 
     def value_to_string(self, obj):
-        '''Customize string value for JSON serialization will'''
+        '''Customize string value for JSON serialization'''
         value = self.value_from_object(obj)
         # return as integer rather than string representation of the flags
         return self.get_prep_value(value)

--- a/mep/accounts/partial_date.py
+++ b/mep/accounts/partial_date.py
@@ -1,9 +1,9 @@
-import re
 import datetime
+import re
 
 from django import forms
-from django.db import models
 from django.core.validators import RegexValidator, ValidationError
+from django.db import models
 from flags import Flags
 
 
@@ -26,6 +26,12 @@ class DatePrecisionField(models.PositiveSmallIntegerField):
         '''Convert values returned from database to :class:`DatePrecision`
         using :meth:`to_python`'''
         return self.to_python(value)
+
+    def value_to_string(self, obj):
+        '''Customize string value for JSON serialization will'''
+        value = self.value_from_object(obj)
+        # return as integer rather than string representation of the flags
+        return self.get_prep_value(value)
 
 
 class PartialDate:

--- a/mep/common/templatetags/mep_tags.py
+++ b/mep/common/templatetags/mep_tags.py
@@ -2,6 +2,7 @@ import json
 from urllib.parse import urlparse
 
 from django.template.defaulttags import mark_safe, register
+from piffle.iiif import IIIFImageClientException
 
 
 @register.filter
@@ -38,3 +39,29 @@ def domain(url):
         return netloc_parts[-2]  # piece right before the top-level domain
     except (TypeError, IndexError, ValueError, AttributeError):
         return None
+
+
+@register.filter
+def iiif_image(img, args):
+    '''Add options to resize or otherwise change the display of an iiif
+    image; expects an instance of :class:`piffle.iiif.IIIFImageClient`.
+    Provide the method and arguments as filter string, i.e.::
+
+        {{ myimg|iiif_image:"size:width=225,height=255" }}
+    '''
+    # split into method and parameters (return if not formatted properly)
+    if ':' not in args:
+        return ''
+    mode, opts = args.split(':')
+    # split parameters into args and kwargs
+    args = opts.split(',')
+    # if there's an =, split it and include in kwargs dict
+    kwargs = dict(arg.split('=', 1) for arg in args if '=' in arg)
+    # otherwise, include as an arg
+    args = [arg for arg in args if '=' not in arg]
+    # attempt to call the method with the arguments
+    try:
+        return getattr(img, mode)(*args, **kwargs)
+    except (IIIFImageClientException, TypeError):
+        # return an empty string if anything goes wrong
+        return ''

--- a/mep/common/tests.py
+++ b/mep/common/tests.py
@@ -15,13 +15,14 @@ from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 from django.views.generic.list import ListView
+from piffle.iiif import IIIFImageClient
 
 from mep.common import SCHEMA_ORG
 from mep.common.admin import LocalUserAdmin
 from mep.common.forms import CheckboxFieldset, FacetChoiceField, FacetForm, \
     RangeField, RangeWidget
 from mep.common.models import AliasIntegerField, DateRange, Named, Notable
-from mep.common.templatetags.mep_tags import dict_item, domain
+from mep.common.templatetags.mep_tags import dict_item, domain, iiif_image
 from mep.common.utils import absolutize_url, alpha_pagelabels
 from mep.common.validators import verify_latlon
 from mep.common import views
@@ -355,6 +356,20 @@ class TestTemplateTags(TestCase):
         assert domain('oops') is None
         assert domain(2) is None
         assert domain(None) is None
+
+    def test_iiif_image(self):
+        myimg = IIIFImageClient('http://image.server/path/', 'myimgid')
+        # check expected behavior
+        assert str(iiif_image(myimg, 'size:width=250')) == \
+            str(myimg.size(width=250))
+        assert str(iiif_image(myimg, 'size:width=250,height=300')) == \
+            str(myimg.size(width=250, height=300))
+        assert str(iiif_image(myimg, 'format:png')) == str(myimg.format('png'))
+
+        # check that errors don't raise exceptions
+        assert iiif_image(myimg, 'bogus') == ''
+        assert iiif_image(myimg, 'size:bogus') == ''
+        assert iiif_image(myimg, 'size:bogus=1') == ''
 
 
 class TestCheckboxFieldset(TestCase):

--- a/mep/footnotes/fixtures/footnotes_gstein.json
+++ b/mep/footnotes/fixtures/footnotes_gstein.json
@@ -1,0 +1,437 @@
+[
+{
+    "model": "djiffy.manifest",
+    "pk": 394,
+    "fields": {
+        "label": "Stein, Gertrude",
+        "short_id": "9f6f307d-2eb7-4960-8dc1-9dec4ea53022",
+        "uri": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest",
+        "metadata": "{\"Date Created\":[\"1920-03-18/1922-04-13\"],\"Extent\":[\"4 cards\"],\"Identifier\":[\"ark:/88435/ws859k779\"],\"Title\":[\"Stein, Gertrude\"],\"Creator\":[\"Beach, Sylvia.\"],\"Language\":[\"English\"],\"Publisher\":[\"Beach, Sylvia.\"],\"Source Metadata Identifier\":[\"C0108_c3660\"],\"Member Of Collections\":[\"Sylvia Beach Papers C0108\"],\"Archival Collection Code\":[\"C0108\"]}",
+        "created": "2019-10-14",
+        "last_modified": "2019-10-14",
+        "extra_data": "{\"https://figgy.princeton.edu/catalog/9f6f307d-2eb7-4960-8dc1-9dec4ea53022.jsonld\":{\"system_updated_at\":\"2019-10-13T23:28:40Z\",\"@context\":\"https://bibdata.princeton.edu/context.json\",\"system_created_at\":\"2019-06-12T22:18:53Z\",\"@id\":\"https://figgy.princeton.edu/catalog/9f6f307d-2eb7-4960-8dc1-9dec4ea53022\",\"identifier\":[\"ark:/88435/ws859k779\"],\"memberOf\":[{\"@type\":\"pcdm:Collection\",\"@id\":\"https://figgy.princeton.edu/catalog/f8201b0f-7ea2-4166-b6b2-033e0de9a6bd\",\"title\":\"Sylvia Beach Papers C0108\"}],\"edm_rights\":{\"@type\":\"dcterms:RightsStatement\",\"@id\":\"http://rightsstatements.org/vocab/NKC/1.0/\",\"pref_label\":\"No Known Copyright\"},\"title\":[{\"@value\":\"Stein, Gertrude\",\"@language\":\"eng\"}]},\"https://findingaids.princeton.edu/collections/C0108/c3660.xml?scope=record\":{},\"logo\":\"https://figgy.princeton.edu/assets/pul_logo_icon-7b5f9384dfa5ca04f4851c6ee9e44e2d6953e55f893472a3e205e1591d3b2ca6.png\",\"license\":\"http://rightsstatements.org/vocab/NKC/1.0/\",\"rendering\":{\"format\":\"text/html\",\"@id\":\"http://arks.princeton.edu/ark:/88435/ws859k779\"}}"
+    }
+},
+{
+    "model": "footnotes.sourcetype",
+    "pk": 2,
+    "fields": {
+        "name": "Lending Library Card",
+        "notes": ""
+    }
+},
+{
+    "model": "books.format",
+    "pk": 1,
+    "fields": {
+        "name": "Book",
+        "notes": "",
+        "uri": "http://schema.org/Book"
+    }
+},
+{
+    "model": "footnotes.bibliography",
+    "pk": 420,
+    "fields": {
+        "notes": "",
+        "bibliographic_note": "Sylvia Beach, Gertrude Stein Lending Library Card, Box 43, Sylvia Beach Papers, Department of Rare Books and Special Collections, Princeton University Library.",
+        "source_type": 2,
+        "manifest": 394
+    }
+},
+{
+    "model": "accounts.event",
+    "pk": 26344,
+    "fields": {
+        "notes": "Year added per JK's research [EG 7/9/18]",
+        "start_date_precision": "DatePrecision(year|month|day)",
+        "end_date_precision": "DatePrecision(year|month|day)",
+        "account": 108,
+        "start_date": "1922-04-03",
+        "end_date": "1922-04-13",
+        "work": 6841,
+        "edition": null
+    }
+},
+{
+    "model": "books.work",
+    "pk": 6841,
+    "fields": {
+        "notes": "OCLCNoMatch",
+        "mep_id": "mep:00r595",
+        "title": "Ursula Trent",
+        "year": 1921,
+        "uri": "",
+        "edition_uri": "",
+        "ebook_url": "",
+        "work_format": null,
+        "updated_at": "2019-06-14T17:44:45Z",
+        "public_notes": "",
+        "genres": [],
+        "subjects": []
+    }
+},
+{
+    "model": "accounts.event",
+    "pk": 26318,
+    "fields": {
+        "notes": "Year updated per JK's research [EG 7/9/18]",
+        "start_date_precision": "DatePrecision(year|month|day)",
+        "end_date_precision": null,
+        "account": 108,
+        "start_date": "1921-01-05",
+        "end_date": null,
+        "work": 5036,
+        "edition": null
+    }
+},
+{
+    "model": "books.work",
+    "pk": 5036,
+    "fields": {
+        "notes": "",
+        "mep_id": "mep:00q36f",
+        "title": "This Side of Paradise",
+        "year": 1920,
+        "uri": "http://worldcat.org/entity/work/id/433248",
+        "edition_uri": "http://www.worldcat.org/oclc/732680439",
+        "ebook_url": "",
+        "work_format": 1,
+        "updated_at": "2019-06-14T17:31:48Z",
+        "public_notes": "",
+        "genres": [],
+        "subjects": []
+    }
+},
+{
+    "model": "accounts.event",
+    "pk": 26296,
+    "fields": {
+        "notes": "Checked card, no return date given [EG 6/11/18]\r\n\r\nYear updated per JK's research [EG 7/9/18]",
+        "start_date_precision": "DatePrecision(year|month|day)",
+        "end_date_precision": null,
+        "account": 108,
+        "start_date": "1920-03-18",
+        "end_date": null,
+        "work": 4000,
+        "edition": null
+    }
+},
+{
+    "model": "books.work",
+    "pk": 4000,
+    "fields": {
+        "notes": "Author: Mary H. Vorse",
+        "mep_id": "mep:00r342",
+        "title": "The Prestons",
+        "year": 1918,
+        "uri": "http://worldcat.org/entity/work/id/2350214",
+        "edition_uri": "http://www.worldcat.org/oclc/504091827",
+        "ebook_url": "",
+        "work_format": 1,
+        "updated_at": "2019-06-14T17:23:31Z",
+        "public_notes": "",
+        "genres": [],
+        "subjects": []
+    }
+},
+{
+    "model": "accounts.event",
+    "pk": 26346,
+    "fields": {
+        "notes": "",
+        "start_date_precision": "DatePrecision(month|day)",
+        "end_date_precision": "DatePrecision(month|day)",
+        "account": 108,
+        "start_date": "1900-01-19",
+        "end_date": "1900-01-24",
+        "work": 7537,
+        "edition": null
+    }
+},
+{
+    "model": "books.work",
+    "pk": 7537,
+    "fields": {
+        "notes": "Variant titles: Hazard of New Fortunes (2 vols.); Hazard of New Fortunes vol 1; Hazard of New Fortunes vol 2\r\n\r\nMULTIVOLUME",
+        "mep_id": "mep:00fs7b",
+        "title": "A Hazard of New Fortunes",
+        "year": 1890,
+        "uri": "http://worldcat.org/entity/work/id/1407958",
+        "edition_uri": "http://www.worldcat.org/oclc/833665285",
+        "ebook_url": "",
+        "work_format": 1,
+        "updated_at": "2019-08-16T19:41:03Z",
+        "public_notes": "",
+        "genres": [],
+        "subjects": []
+    }
+},
+{
+    "model": "accounts.event",
+    "pk": 26301,
+    "fields": {
+        "notes": "volume 2 vols\r\n[EG 6/11/18]\r\n\r\nYear updated per JK's research [EG 7/9/18]",
+        "start_date_precision": null,
+        "end_date_precision": "DatePrecision(year|month|day)",
+        "account": 108,
+        "start_date": null,
+        "end_date": "1920-06-03",
+        "work": 2320,
+        "edition": null
+    }
+},
+{
+    "model": "books.work",
+    "pk": 2320,
+    "fields": {
+        "notes": "Variant Titles: Letters of Meredith\nVariant titles: Letters of G. Meredith\nMerged on 2019-09-12 with MEP id mep:00v728",
+        "mep_id": "mep:00r389",
+        "title": "Letters of George Meredith",
+        "year": 1912,
+        "uri": "http://worldcat.org/entity/work/id/4757735803",
+        "edition_uri": "http://www.worldcat.org/oclc/313022250",
+        "ebook_url": "",
+        "work_format": 1,
+        "updated_at": "2019-09-12T17:33:24Z",
+        "public_notes": "",
+        "genres": [],
+        "subjects": []
+    }
+},
+{
+    "model": "accounts.account",
+    "pk": 108,
+    "fields": {
+        "card": 420,
+        "persons": [
+            517
+        ]
+    }
+},
+{
+    "model": "accounts.borrow",
+    "pk": 26344,
+    "fields": {
+        "item_status": "R"
+    }
+},
+{
+    "model": "accounts.borrow",
+    "pk": 26318,
+    "fields": {
+        "item_status": ""
+    }
+},
+{
+    "model": "accounts.borrow",
+    "pk": 26296,
+    "fields": {
+        "item_status": ""
+    }
+},
+{
+    "model": "accounts.borrow",
+    "pk": 26346,
+    "fields": {
+        "item_status": "R"
+    }
+},
+{
+    "model": "accounts.borrow",
+    "pk": 26301,
+    "fields": {
+        "item_status": "R"
+    }
+},
+{
+    "model": "djiffy.manifest",
+    "pk": 336,
+    "fields": {
+        "label": "Stein, Leo",
+        "short_id": "8493520c-be69-47f1-b159-262f4b8c0e04",
+        "uri": "https://figgy.princeton.edu/concern/scanned_resources/8493520c-be69-47f1-b159-262f4b8c0e04/manifest",
+        "metadata": "{\"Date Created\":[\"1923-08-20/1933-06-17\"],\"Extent\":[\"5 cards\"],\"Identifier\":[\"ark:/88435/3n204320r\"],\"Title\":[\"Stein, Leo\"],\"Creator\":[\"Beach, Sylvia.\"],\"Language\":[\"English\"],\"Publisher\":[\"Beach, Sylvia.\"],\"Source Metadata Identifier\":[\"C0108_c3661\"],\"Member Of Collections\":[\"Sylvia Beach Papers C0108\"],\"Archival Collection Code\":[\"C0108\"]}",
+        "created": "2019-10-14",
+        "last_modified": "2019-10-14",
+        "extra_data": "{\"https://figgy.princeton.edu/catalog/8493520c-be69-47f1-b159-262f4b8c0e04.jsonld\":{\"system_updated_at\":\"2019-10-13T23:32:12Z\",\"@context\":\"https://bibdata.princeton.edu/context.json\",\"system_created_at\":\"2019-06-12T22:19:04Z\",\"@id\":\"https://figgy.princeton.edu/catalog/8493520c-be69-47f1-b159-262f4b8c0e04\",\"identifier\":[\"ark:/88435/3n204320r\"],\"memberOf\":[{\"@type\":\"pcdm:Collection\",\"@id\":\"https://figgy.princeton.edu/catalog/f8201b0f-7ea2-4166-b6b2-033e0de9a6bd\",\"title\":\"Sylvia Beach Papers C0108\"}],\"edm_rights\":{\"@type\":\"dcterms:RightsStatement\",\"@id\":\"http://rightsstatements.org/vocab/NKC/1.0/\",\"pref_label\":\"No Known Copyright\"},\"title\":[{\"@value\":\"Stein, Leo\",\"@language\":\"eng\"}]},\"https://findingaids.princeton.edu/collections/C0108/c3661.xml?scope=record\":{},\"logo\":\"https://figgy.princeton.edu/assets/pul_logo_icon-7b5f9384dfa5ca04f4851c6ee9e44e2d6953e55f893472a3e205e1591d3b2ca6.png\",\"license\":\"http://rightsstatements.org/vocab/NKC/1.0/\",\"rendering\":{\"format\":\"text/html\",\"@id\":\"http://arks.princeton.edu/ark:/88435/3n204320r\"}}"
+    }
+},
+{
+    "model": "djiffy.manifest",
+    "pk": 394,
+    "fields": {
+        "label": "Stein, Gertrude",
+        "short_id": "9f6f307d-2eb7-4960-8dc1-9dec4ea53022",
+        "uri": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest",
+        "metadata": "{\"Date Created\":[\"1920-03-18/1922-04-13\"],\"Extent\":[\"4 cards\"],\"Identifier\":[\"ark:/88435/ws859k779\"],\"Title\":[\"Stein, Gertrude\"],\"Creator\":[\"Beach, Sylvia.\"],\"Language\":[\"English\"],\"Publisher\":[\"Beach, Sylvia.\"],\"Source Metadata Identifier\":[\"C0108_c3660\"],\"Member Of Collections\":[\"Sylvia Beach Papers C0108\"],\"Archival Collection Code\":[\"C0108\"]}",
+        "created": "2019-10-14",
+        "last_modified": "2019-10-14",
+        "extra_data": "{\"https://figgy.princeton.edu/catalog/9f6f307d-2eb7-4960-8dc1-9dec4ea53022.jsonld\":{\"system_updated_at\":\"2019-10-13T23:28:40Z\",\"@context\":\"https://bibdata.princeton.edu/context.json\",\"system_created_at\":\"2019-06-12T22:18:53Z\",\"@id\":\"https://figgy.princeton.edu/catalog/9f6f307d-2eb7-4960-8dc1-9dec4ea53022\",\"identifier\":[\"ark:/88435/ws859k779\"],\"memberOf\":[{\"@type\":\"pcdm:Collection\",\"@id\":\"https://figgy.princeton.edu/catalog/f8201b0f-7ea2-4166-b6b2-033e0de9a6bd\",\"title\":\"Sylvia Beach Papers C0108\"}],\"edm_rights\":{\"@type\":\"dcterms:RightsStatement\",\"@id\":\"http://rightsstatements.org/vocab/NKC/1.0/\",\"pref_label\":\"No Known Copyright\"},\"title\":[{\"@value\":\"Stein, Gertrude\",\"@language\":\"eng\"}]},\"https://findingaids.princeton.edu/collections/C0108/c3660.xml?scope=record\":{},\"logo\":\"https://figgy.princeton.edu/assets/pul_logo_icon-7b5f9384dfa5ca04f4851c6ee9e44e2d6953e55f893472a3e205e1591d3b2ca6.png\",\"license\":\"http://rightsstatements.org/vocab/NKC/1.0/\",\"rendering\":{\"format\":\"text/html\",\"@id\":\"http://arks.princeton.edu/ark:/88435/ws859k779\"}}"
+    }
+},
+{
+    "model": "djiffy.canvas",
+    "pk": 1191,
+    "fields": {
+        "label": "9",
+        "short_id": "9242203d-d33e-416a-8658-59ec52b46736",
+        "uri": "https://figgy.princeton.edu/concern/scanned_resources/8493520c-be69-47f1-b159-262f4b8c0e04/manifest/canvas/9242203d-d33e-416a-8658-59ec52b46736",
+        "iiif_image_id": "https://iiif.princeton.edu/loris/figgy_prod/62%2F77%2F6f%2F62776f401c1744f3b61c996bf9ac6f1c%2Fintermediate_file.jp2",
+        "manifest": 336,
+        "thumbnail": false,
+        "order": 8,
+        "extra_data": "{\"rendering\":[{\"format\":\"image/tiff\",\"@id\":\"https://figgy.princeton.edu/downloads/9242203d-d33e-416a-8658-59ec52b46736/file/89fadffe-567e-4926-8dd2-5ddbe192f19d\",\"label\":\"Download the original file\"}]}"
+    }
+},
+{
+    "model": "footnotes.bibliography",
+    "pk": 468,
+    "fields": {
+        "notes": "",
+        "bibliographic_note": "Sylvia Beach, Leo Stein Lending Library Card, Box 43, Sylvia Beach Papers, Department of Rare Books and Special Collections, Princeton University Library.",
+        "source_type": 2,
+        "manifest": 336
+    }
+},
+{
+    "model": "djiffy.canvas",
+    "pk": 1411,
+    "fields": {
+        "label": "5",
+        "short_id": "9d839618-9d3e-4e8e-9d6c-28b46d337b11",
+        "uri": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest/canvas/9d839618-9d3e-4e8e-9d6c-28b46d337b11",
+        "iiif_image_id": "https://iiif.princeton.edu/loris/figgy_prod/87%2F12%2Ffe%2F8712fe479f4f46f0a4647976f6d44102%2Fintermediate_file.jp2",
+        "manifest": 394,
+        "thumbnail": false,
+        "order": 4,
+        "extra_data": "{\"rendering\":[{\"format\":\"image/tiff\",\"@id\":\"https://figgy.princeton.edu/downloads/9d839618-9d3e-4e8e-9d6c-28b46d337b11/file/209ebdda-b57d-4e1d-9e36-193eb4a3df12\",\"label\":\"Download the original file\"}]}"
+    }
+},
+{
+    "model": "djiffy.canvas",
+    "pk": 1409,
+    "fields": {
+        "label": "3",
+        "short_id": "d3182e87-bc20-44f9-a92b-ff978de18d37",
+        "uri": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest/canvas/d3182e87-bc20-44f9-a92b-ff978de18d37",
+        "iiif_image_id": "https://iiif.princeton.edu/loris/figgy_prod/07%2Fb7%2F83%2F07b7834be68d4584bb89d8ef97efcf11%2Fintermediate_file.jp2",
+        "manifest": 394,
+        "thumbnail": false,
+        "order": 2,
+        "extra_data": "{\"rendering\":[{\"format\":\"image/tiff\",\"@id\":\"https://figgy.princeton.edu/downloads/d3182e87-bc20-44f9-a92b-ff978de18d37/file/12a43393-1d18-4414-85b3-9fcb966e2231\",\"label\":\"Download the original file\"}]}"
+    }
+},
+{
+    "model": "djiffy.canvas",
+    "pk": 1408,
+    "fields": {
+        "label": "2",
+        "short_id": "68fd36f1-a463-441e-9f13-dfc4a6cd4114",
+        "uri": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest/canvas/68fd36f1-a463-441e-9f13-dfc4a6cd4114",
+        "iiif_image_id": "https://iiif.princeton.edu/loris/figgy_prod/4e%2F51%2F33%2F4e5133fc38ac495ba74a000ffc979d4f%2Fintermediate_file.jp2",
+        "manifest": 394,
+        "thumbnail": false,
+        "order": 1,
+        "extra_data": "{\"rendering\":[{\"format\":\"image/tiff\",\"@id\":\"https://figgy.princeton.edu/downloads/68fd36f1-a463-441e-9f13-dfc4a6cd4114/file/79be0c46-98e6-4999-80f3-372eb8dfcae9\",\"label\":\"Download the original file\"}]}"
+    }
+},
+{
+    "model": "djiffy.canvas",
+    "pk": 1407,
+    "fields": {
+        "label": "1",
+        "short_id": "31f9c24e-6f97-4149-afb2-e9d2f7ba6cbe",
+        "uri": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest/canvas/31f9c24e-6f97-4149-afb2-e9d2f7ba6cbe",
+        "iiif_image_id": "https://iiif.princeton.edu/loris/figgy_prod/12%2Fe6%2F12%2F12e612fbcef343bcb74f5bec1a44a4f8%2Fintermediate_file.jp2",
+        "manifest": 394,
+        "thumbnail": true,
+        "order": 0,
+        "extra_data": "{\"rendering\":[{\"format\":\"image/tiff\",\"@id\":\"https://figgy.princeton.edu/downloads/31f9c24e-6f97-4149-afb2-e9d2f7ba6cbe/file/73c0d641-1718-43e9-a904-b91184935dde\",\"label\":\"Download the original file\"}]}"
+    }
+},
+{
+    "model": "footnotes.footnote",
+    "pk": 21464,
+    "fields": {
+        "notes": "",
+        "bibliography": 468,
+        "location": "https://figgy.princeton.edu/concern/scanned_resources/8493520c-be69-47f1-b159-262f4b8c0e04/manifest/canvas/9242203d-d33e-416a-8658-59ec52b46736",
+        "snippet_text": "",
+        "content_type": 2,
+        "object_id": 32559,
+        "is_agree": true,
+        "image": 1191
+    }
+},
+{
+    "model": "footnotes.footnote",
+    "pk": 15397,
+    "fields": {
+        "notes": "",
+        "bibliography": 420,
+        "location": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest/canvas/9d839618-9d3e-4e8e-9d6c-28b46d337b11",
+        "snippet_text": "",
+        "content_type": 3,
+        "object_id": 26346,
+        "is_agree": true,
+        "image": 1411
+    }
+},
+{
+    "model": "footnotes.footnote",
+    "pk": 15395,
+    "fields": {
+        "notes": "",
+        "bibliography": 420,
+        "location": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest/canvas/d3182e87-bc20-44f9-a92b-ff978de18d37",
+        "snippet_text": "",
+        "content_type": 3,
+        "object_id": 26344,
+        "is_agree": true,
+        "image": 1409
+    }
+},
+{
+    "model": "footnotes.footnote",
+    "pk": 15369,
+    "fields": {
+        "notes": "",
+        "bibliography": 420,
+        "location": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest/canvas/68fd36f1-a463-441e-9f13-dfc4a6cd4114",
+        "snippet_text": "",
+        "content_type": 3,
+        "object_id": 26318,
+        "is_agree": true,
+        "image": 1408
+    }
+},
+{
+    "model": "footnotes.footnote",
+    "pk": 15352,
+    "fields": {
+        "notes": "",
+        "bibliography": 420,
+        "location": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest/canvas/31f9c24e-6f97-4149-afb2-e9d2f7ba6cbe",
+        "snippet_text": "",
+        "content_type": 3,
+        "object_id": 26301,
+        "is_agree": true,
+        "image": 1407
+    }
+},
+{
+    "model": "footnotes.footnote",
+    "pk": 15347,
+    "fields": {
+        "notes": "",
+        "bibliography": 420,
+        "location": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest/canvas/31f9c24e-6f97-4149-afb2-e9d2f7ba6cbe",
+        "snippet_text": "",
+        "content_type": 3,
+        "object_id": 26296,
+        "is_agree": true,
+        "image": 1407
+    }
+}
+]

--- a/mep/footnotes/fixtures/footnotes_gstein.json
+++ b/mep/footnotes/fixtures/footnotes_gstein.json
@@ -44,8 +44,8 @@
     "pk": 26344,
     "fields": {
         "notes": "Year added per JK's research [EG 7/9/18]",
-        "start_date_precision": "DatePrecision(year|month|day)",
-        "end_date_precision": "DatePrecision(year|month|day)",
+        "start_date_precision": 7,
+        "end_date_precision": 7,
         "account": 108,
         "start_date": "1922-04-03",
         "end_date": "1922-04-13",
@@ -76,7 +76,7 @@
     "pk": 26318,
     "fields": {
         "notes": "Year updated per JK's research [EG 7/9/18]",
-        "start_date_precision": "DatePrecision(year|month|day)",
+        "start_date_precision": 7,
         "end_date_precision": null,
         "account": 108,
         "start_date": "1921-01-05",
@@ -108,7 +108,7 @@
     "pk": 26296,
     "fields": {
         "notes": "Checked card, no return date given [EG 6/11/18]\r\n\r\nYear updated per JK's research [EG 7/9/18]",
-        "start_date_precision": "DatePrecision(year|month|day)",
+        "start_date_precision": 7,
         "end_date_precision": null,
         "account": 108,
         "start_date": "1920-03-18",
@@ -140,8 +140,8 @@
     "pk": 26346,
     "fields": {
         "notes": "",
-        "start_date_precision": "DatePrecision(month|day)",
-        "end_date_precision": "DatePrecision(month|day)",
+        "start_date_precision": 6,
+        "end_date_precision": 6,
         "account": 108,
         "start_date": "1900-01-19",
         "end_date": "1900-01-24",
@@ -173,7 +173,7 @@
     "fields": {
         "notes": "volume 2 vols\r\n[EG 6/11/18]\r\n\r\nYear updated per JK's research [EG 7/9/18]",
         "start_date_precision": null,
-        "end_date_precision": "DatePrecision(year|month|day)",
+        "end_date_precision": 7,
         "account": 108,
         "start_date": null,
         "end_date": "1920-06-03",

--- a/mep/footnotes/fixtures/footnotes_gstein.json
+++ b/mep/footnotes/fixtures/footnotes_gstein.json
@@ -380,7 +380,10 @@
         "bibliography": 468,
         "location": "https://figgy.princeton.edu/concern/scanned_resources/8493520c-be69-47f1-b159-262f4b8c0e04/manifest/canvas/9242203d-d33e-416a-8658-59ec52b46736",
         "snippet_text": "",
-        "content_type": 2,
+         "content_type": [
+            "accounts",
+            "borrow"
+        ],
         "object_id": 32559,
         "is_agree": true,
         "image": 1191
@@ -394,7 +397,10 @@
         "bibliography": 420,
         "location": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest/canvas/9d839618-9d3e-4e8e-9d6c-28b46d337b11",
         "snippet_text": "",
-        "content_type": 3,
+        "content_type": [
+            "accounts",
+            "borrow"
+        ],
         "object_id": 26346,
         "is_agree": true,
         "image": 1411
@@ -408,7 +414,10 @@
         "bibliography": 420,
         "location": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest/canvas/d3182e87-bc20-44f9-a92b-ff978de18d37",
         "snippet_text": "",
-        "content_type": 3,
+         "content_type": [
+            "accounts",
+            "borrow"
+        ],
         "object_id": 26344,
         "is_agree": true,
         "image": 1409
@@ -422,7 +431,10 @@
         "bibliography": 420,
         "location": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest/canvas/68fd36f1-a463-441e-9f13-dfc4a6cd4114",
         "snippet_text": "",
-        "content_type": 3,
+         "content_type": [
+            "accounts",
+            "borrow"
+        ],
         "object_id": 26318,
         "is_agree": true,
         "image": 1408
@@ -436,7 +448,10 @@
         "bibliography": 420,
         "location": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest/canvas/31f9c24e-6f97-4149-afb2-e9d2f7ba6cbe",
         "snippet_text": "",
-        "content_type": 3,
+         "content_type": [
+            "accounts",
+            "borrow"
+        ],
         "object_id": 26301,
         "is_agree": true,
         "image": 1407
@@ -450,7 +465,10 @@
         "bibliography": 420,
         "location": "https://figgy.princeton.edu/concern/scanned_resources/9f6f307d-2eb7-4960-8dc1-9dec4ea53022/manifest/canvas/31f9c24e-6f97-4149-afb2-e9d2f7ba6cbe",
         "snippet_text": "",
-        "content_type": 3,
+         "content_type": [
+            "accounts",
+            "borrow"
+        ],
         "object_id": 26296,
         "is_agree": true,
         "image": 1407

--- a/mep/footnotes/fixtures/footnotes_gstein.json
+++ b/mep/footnotes/fixtures/footnotes_gstein.json
@@ -200,6 +200,28 @@
     }
 },
 {
+    "model": "people.person",
+    "pk": 517,
+    "fields": {
+        "notes": "[ID 10.18]: re the 16 March 1920 sub event: I think that, in the logbook, the straight line next to Stein's name indicates that she took the same sub pattern as the person above her in the book: 1 year 2 vols. This is borne out by her subsequent sub events.",
+        "start_year": 1874,
+        "end_year": 1946,
+        "mep_id": "stei.ge",
+        "name": "Gertrude Stein",
+        "sort_name": "Stein, Gertrude",
+        "viaf_id": "http://viaf.org/viaf/22149082",
+        "is_organization": false,
+        "verified": false,
+        "slug": "stein-gertrude",
+        "updated_at": "2019-11-15T16:55:41Z",
+        "gender": "F",
+        "title": "",
+        "profession": null,
+        "public_notes": "",
+        "nationalities": []
+    }
+},
+{
     "model": "accounts.account",
     "pk": 108,
     "fields": {

--- a/mep/footnotes/models.py
+++ b/mep/footnotes/models.py
@@ -334,7 +334,7 @@ class FootnoteQuerySet(models.QuerySet):
             .annotate(
             start_year_known=models.Case(
                 models.When(
-                    start_precision=DatePrecision.month | DatePrecision.day,
+                    start_precision=int(DatePrecision.month | DatePrecision.day),
                     then=models.Value(False),
                 ),
                 default=models.Value(True),
@@ -342,7 +342,7 @@ class FootnoteQuerySet(models.QuerySet):
             ),
             end_year_known=models.Case(
                 models.When(
-                    end_precision=DatePrecision.month | DatePrecision.day,
+                    end_precision=int(DatePrecision.month | DatePrecision.day),
                     then=models.Value(False),
                 ),
                 default=models.Value(True),

--- a/mep/footnotes/models.py
+++ b/mep/footnotes/models.py
@@ -30,7 +30,6 @@ class BibliographySignalHandlers:
         # raw = saved as presented; don't query the database
         if raw:
             return
-        print('bibliography person save')
         if not instance.pk:
             return
         # find any cards associated via an account
@@ -314,7 +313,8 @@ class FootnoteQuerySet(models.QuerySet):
             event_ids_by_type[ref['content_type']].append(ref['object_id'])
 
         # construct an OR filter query for each content type and list of ids
-        filter_q = models.Q()
+        # - look for nothing OR for events and event subtypes by id
+        filter_q = models.Q(pk__in=[])
         for ctype, pk_list in event_ids_by_type.items():
             if ctype_lookup[ctype] == 'borrow':
                 filter_q |= models.Q(borrow__pk__in=pk_list)

--- a/mep/footnotes/models.py
+++ b/mep/footnotes/models.py
@@ -28,9 +28,7 @@ class BibliographySignalHandlers:
     @staticmethod
     def person_save(sender=None, instance=None, raw=False, **kwargs):
         # raw = saved as presented; don't query the database
-        if raw:
-            return
-        if not instance.pk:
+        if raw or not instance.pk:
             return
         # find any cards associated via an account
         cards = Bibliography.objects.filter(account__persons__pk=instance.pk)
@@ -300,7 +298,7 @@ class FootnoteQuerySet(models.QuerySet):
         # get a list of the event content types we care about
         event_content_types = ContentType.objects.filter(
             app_label='accounts',
-            model__in=['Event', 'Borrow', 'Purchase'])
+            model__in=['event', 'borrow', 'purchase'])
         # lookup dict: content type pk and model name
         ctype_lookup = {ctype.pk: ctype.name for ctype in event_content_types}
 
@@ -311,7 +309,6 @@ class FootnoteQuerySet(models.QuerySet):
         event_ids_by_type = defaultdict(list)
         for ref in event_refs:
             event_ids_by_type[ref['content_type']].append(ref['object_id'])
-
         # construct an OR filter query for each content type and list of ids
         # - look for nothing OR for events and event subtypes by id
         filter_q = models.Q(pk__in=[])

--- a/mep/footnotes/tests/test_footnote_models.py
+++ b/mep/footnotes/tests/test_footnote_models.py
@@ -146,8 +146,10 @@ class TestFootnoteQuerySet(TestCase):
         evt = Event.objects.known_years() \
                    .filter(start_date__isnull=False, end_date__isnull=False) \
                    .first()
-        assert Footnote.objects.filter(object_id=evt.id).event_date_range() \
-            == (evt.start_date, evt.end_date)
+        footnote_dates = Footnote.objects.filter(object_id=evt.id) \
+                                 .event_date_range()
+        assert footnote_dates[0] == evt.start_date
+        assert footnote_dates[1] == evt.end_date
 
         # full date range should be min/max of all events from the account
         acct = Account.objects.first()  # currently only g. stein in fixture

--- a/mep/footnotes/tests/test_footnote_models.py
+++ b/mep/footnotes/tests/test_footnote_models.py
@@ -159,6 +159,26 @@ class TestFootnoteQuerySet(TestCase):
         assert footnote_dates[0] == event_dates[0]
         assert footnote_dates[1] == event_dates[-1]
 
+        # add new purchase and generic events with footnotes
+        generic_event = Event.objects.create(
+            account=evt.account, start_date=date(1919, 11, 17))
+        evt_ctype = ContentType.objects.get_for_model(Event)
+        bib = evt.footnotes.first().bibliography
+        Footnote.objects.create(object_id=generic_event.pk,
+                                content_type=evt_ctype, bibliography=bib)
+        footnote_dates = Footnote.objects.filter(**gstein_filter) \
+            .event_date_range()
+        assert footnote_dates[0] == generic_event.start_date
+
+        purchase_evt = Purchase.objects.create(
+            account=evt.account, start_date=date(1962, 3, 5))
+        evt_ctype = ContentType.objects.get_for_model(Purchase)
+        Footnote.objects.create(object_id=purchase_evt.pk,
+                                content_type=evt_ctype, bibliography=bib)
+        footnote_dates = Footnote.objects.filter(**gstein_filter) \
+            .event_date_range()
+        assert footnote_dates[1] == purchase_evt.start_date
+
 
 class TestBibliographyAdmin:
 

--- a/mep/footnotes/tests/test_footnote_models.py
+++ b/mep/footnotes/tests/test_footnote_models.py
@@ -144,7 +144,8 @@ class TestFootnoteQuerySet(TestCase):
 
         # get a known date from the fixture with start and end date fully known
         evt = Borrow.objects.get(pk=26344)
-        footnote_dates = evt.event_footnotes.event_date_range()
+        footnote_dates = evt.footnotes.all().event_date_range()
+
         # should not be null
         assert footnote_dates
         assert footnote_dates[0] == evt.start_date

--- a/mep/footnotes/tests/test_footnote_models.py
+++ b/mep/footnotes/tests/test_footnote_models.py
@@ -142,12 +142,11 @@ class TestFootnoteQuerySet(TestCase):
         assert not Footnote.objects.exclude(**gstein_filter) \
             .event_date_range()
 
-        # first test footnote for one event with known years and start/end
-        evt = Event.objects.known_years() \
-                   .filter(start_date__isnull=False, end_date__isnull=False) \
-                   .first()
-        footnote_dates = Footnote.objects.filter(object_id=evt.id) \
-                                 .event_date_range()
+        # get a known date from the fixture with start and end date fully known
+        evt = Borrow.objects.get(pk=26344)
+        footnote_dates = evt.event_footnotes.event_date_range()
+        # should not be null
+        assert footnote_dates
         assert footnote_dates[0] == evt.start_date
         assert footnote_dates[1] == evt.end_date
 

--- a/mep/pages/templates/pages/snippets/creators.html
+++ b/mep/pages/templates/pages/snippets/creators.html
@@ -1,3 +1,4 @@
+{# always display attribution for publication date, even if creators author & editor are not set #}
 <div class="attribution">
     {% if page.authors %}
     <span class="authors">

--- a/mep/people/templates/people/member_cardlist.html
+++ b/mep/people/templates/people/member_cardlist.html
@@ -42,11 +42,11 @@
                 </picture>
                 {% with card.footnote_set.event_date_range as dates %}
                 <div class="card-dates {% if not dates %}unknown{% endif %}">
-                    <dt>Card Years</dt>
-                    <dd>{% if dates.0 %}{{ dates.0.year }}
+                    <span class="label">Card Years</span>
+                    <span>{% if dates.0 %}{{ dates.0.year }}
                         {% if dates.0.year != dates.1.year %}–<span class="sr-only">to</span> {{ dates.1.year }}{% endif %}
                         {% else %}Unknown{% endif %}
-                    </dd>
+                    </span>
                 </div>
                 {% endwith %}
         {# </a> #}

--- a/mep/people/templates/people/member_cardlist.html
+++ b/mep/people/templates/people/member_cardlist.html
@@ -29,6 +29,7 @@
 </nav>
 
 <section class="member-cards">
+    {% if  cards %}
     <ol class="card-results">
     {% for card in cards %}
     <li class="card result">
@@ -51,10 +52,11 @@
                 {% endwith %}
         {# </a> #}
     </li>
-    {% empty %}
-    <li>No cards available.</li>
     {% endfor %}
     </ol>
+    {% else %}
+    <div>No cards available.</div>
+    {% endif %}
 
 </section>
 {% endblock %}

--- a/mep/people/templates/people/member_cardlist.html
+++ b/mep/people/templates/people/member_cardlist.html
@@ -2,7 +2,7 @@
 {% load render_bundle from webpack_loader %}
 {% load static mep_tags %}
 
-{% block page-subtitle %}{{ member.firstname_last }} Membership Activity · Library Members · {% endblock %}
+{% block page-subtitle %}{{ member.firstname_last }} Cards · Library Members · {% endblock %}
 
 {% block js %}
 {% render_bundle 'activities' 'js' %}
@@ -28,8 +28,8 @@
     </li>
 </nav>
 
-<section class="cards">
-    <ul class="card-results">
+<section class="member-cards">
+    <ol class="card-results">
     {% for card in cards %}
     <li class="card result">
         {# <a href="#" aria-label=""> #}
@@ -52,7 +52,7 @@
         {# </a> #}
     </li>
     {% endfor %}
-</ul>
+    </ol>
 
 </section>
 {% endblock %}

--- a/mep/people/templates/people/member_cardlist.html
+++ b/mep/people/templates/people/member_cardlist.html
@@ -41,7 +41,7 @@
                   {% endwith %}
                 </picture>
                 {% with card.footnote_set.event_date_range as dates %}
-                <div class="card-dates">
+                <div class="card-dates {% if not dates %}unknown{% endif %}">
                     <dt>Card Years</dt>
                     <dd>{% if dates.0 %}{{ dates.0.year }}
                         {% if dates.0.year != dates.1.year %}–<span class="sr-only">to</span> {{ dates.1.year }}{% endif %}

--- a/mep/people/templates/people/member_cardlist.html
+++ b/mep/people/templates/people/member_cardlist.html
@@ -51,6 +51,8 @@
                 {% endwith %}
         {# </a> #}
     </li>
+    {% empty %}
+    <li>No cards</li>
     {% endfor %}
     </ol>
 

--- a/mep/people/templates/people/member_cardlist.html
+++ b/mep/people/templates/people/member_cardlist.html
@@ -1,0 +1,58 @@
+{% extends 'base.html' %}
+{% load render_bundle from webpack_loader %}
+{% load static mep_tags %}
+
+{% block page-subtitle %}{{ member.firstname_last }} Membership Activity · Library Members · {% endblock %}
+
+{% block js %}
+{% render_bundle 'activities' 'js' %}
+{% endblock %}
+
+{% block header %}
+{% include 'snippets/header.html' with title=member.firstname_last style="detail" %}
+{% endblock %}
+
+{% block main-style %}tabbed white{% endblock %}
+
+{% block content %}
+{% include 'snippets/breadcrumbs.html' %}
+<nav class="tabs" aria-label="sections">
+    <li class="tab">
+        <a href="{% url 'people:member-detail' slug=member.slug %}">biography</a>
+    </li>
+    <li class="tab">
+        <a href="{% url 'people:membership-activities' slug=member.slug %}">activities</a>
+    </li>
+    <li class="tab" aria-selected="true">
+        <span>cards</span>
+    </li>
+</nav>
+
+<section class="cards">
+    <ul class="card-results">
+    {% for card in cards %}
+    <li class="card result">
+        {# <a href="#" aria-label=""> #}
+                {# card thumbnails and year if known #}
+                <picture>
+                  {% with card.image|iiif_image:"size:width=225" as 1xthumbnail %}
+                    <source srcset="{{ 1xthumbnail }}, {{ card.image|iiif_image:"size:width=450" }} 2x">
+                    <img src="{{ 1xthumbnail }}" alt="">
+                  {% endwith %}
+                </picture>
+                {% with card.footnote_set.event_date_range as dates %}
+                <div class="card-dates">
+                    <dt>Card Years</dt>
+                    <dd>{% if dates.0 %}{{ dates.0.year }}
+                        {% if dates.0.year != dates.1.year %}–<span class="sr-only">to</span> {{ dates.1.year }}{% endif %}
+                        {% else %}Unknown{% endif %}
+                    </dd>
+                </div>
+                {% endwith %}
+        {# </a> #}
+    </li>
+    {% endfor %}
+</ul>
+
+</section>
+{% endblock %}

--- a/mep/people/templates/people/member_cardlist.html
+++ b/mep/people/templates/people/member_cardlist.html
@@ -52,7 +52,7 @@
         {# </a> #}
     </li>
     {% empty %}
-    <li>No cards</li>
+    <li>No cards available.</li>
     {% endfor %}
     </ol>
 

--- a/mep/people/templates/people/member_detail.html
+++ b/mep/people/templates/people/member_detail.html
@@ -32,7 +32,7 @@
         <a href="{% url 'people:membership-activities' slug=member.slug %}">activities</a>
     </li>
     <li class="tab">
-        <a href="#">cards</a>
+        <a href="{% url 'people:member-cardlist' slug=member.slug %}">cards</a>
     </li>
 </nav>
 

--- a/mep/people/templates/people/membership_activities.html
+++ b/mep/people/templates/people/membership_activities.html
@@ -23,8 +23,8 @@
     <li class="tab" aria-selected="true">
         <a href="{% url 'people:membership-activities' slug=member.slug %}">activities</a>
     </li>
-    <li class="tab pending">
-        <span>cards</span>
+    <li class="tab">
+        <a href="{% url 'people:member-cardlist' slug=member.slug %}">cards</a>
     </li>
 </nav>
 

--- a/mep/people/tests/test_views.py
+++ b/mep/people/tests/test_views.py
@@ -13,19 +13,21 @@ from django.http import Http404, JsonResponse
 from django.template.defaultfilters import date as format_date
 from django.test import RequestFactory, TestCase
 from django.urls import resolve, reverse
+from djiffy.models import Canvas
 
 from mep.accounts.models import (Account, Address, Event, Reimbursement,
                                  Subscription, SubscriptionType)
 from mep.books.models import Creator, CreatorType, Work
 from mep.common.utils import absolutize_url, login_temporarily_required
-from mep.footnotes.models import Bibliography, SourceType
+from mep.footnotes.models import Bibliography, Footnote, SourceType
 from mep.people.admin import GeoNamesLookupWidget, MapWidget
 from mep.people.forms import PersonMergeForm
 from mep.people.geonames import GeoNamesAPI
 from mep.people.models import (Country, Location, Person, Relationship,
                                RelationshipType)
 from mep.people.views import (GeoNamesLookup, MembershipActivities,
-                              MembershipGraphs, MembersList, PersonMerge)
+                              MembershipGraphs, MembersList, PersonMerge,
+                              MemberCardList)
 
 
 class TestPeopleViews(TestCase):
@@ -1094,7 +1096,7 @@ class TestMembershipActivities(TestCase):
         assert crumbs[-1][1] == self.view.get_absolute_url()
         # second to last is member page
         assert crumbs[-2][0] == self.member.short_name
-        assert crumbs[-2][1] == self.member.get_absolute_url()
+        assert crumbs[-2][1] == absolutize_url(self.member.get_absolute_url())
 
     @login_temporarily_required
     def test_view_template(self):
@@ -1179,3 +1181,80 @@ class TestMembershipGraphs(TestCase):
             'startDate': '1926-01-01',
             'count': 242
         }
+
+
+class TestMemberCardList(TestCase):
+    fixtures = ['footnotes_gstein']
+
+    def test_get_queryset(self):
+        view = MemberCardList()
+        # invalid slug should result in a 404
+        view.kwargs = {'slug': 'bogus'}
+        with pytest.raises(Http404):
+            view.get_queryset()
+
+        view.kwargs = {'slug': 'stein-gertrude'}
+        canvas_ids = list(view.get_queryset().values_list('pk', flat=True))
+        # member should be stored on the view
+        assert view.member == Person.objects.get(slug='stein-gertrude')
+        # queryset should be canvas ids for footnotes associated with Stein
+        assert canvas_ids == list(Footnote.objects.filter(
+            bibliography__bibliographic_note__contains='Gertrude Stein'
+        ).values_list('image__pk', flat=True).distinct())
+
+    def test_get_absolute_url(self):
+        view = MemberCardList()
+        view.kwargs = {'slug': 'stein'}
+        assert view.get_absolute_url() == \
+            absolutize_url(reverse('people:member-cardlist',
+                                   kwargs=view.kwargs))
+
+    def test_get_breadcrumbs(self):
+        view = MemberCardList()
+        view.kwargs = {'slug': 'stein-gertrude'}
+        # get queryset to populate member & object
+        view.get_queryset()
+        crumbs = view.get_breadcrumbs()
+        assert crumbs[0][0] == 'Home'
+        # last item is this page
+        assert crumbs[-1][0] == 'Cards'
+        assert crumbs[-1][1] == view.get_absolute_url()
+        # second to last is member page
+        assert crumbs[-2][0] == view.member.short_name
+        assert crumbs[-2][1] == absolutize_url(view.member.get_absolute_url())
+
+    def test_get_context_data(self):
+        view = MemberCardList()
+        view.kwargs = {'slug': 'stein-gertrude'}
+        view.object_list = view.get_queryset()
+        context = view.get_context_data()
+        assert context['member'] == view.member
+
+    @login_temporarily_required
+    def test_view_template(self):
+        member = Person.objects.get(slug='stein-gertrude')
+        response = self.client.get(reverse('people:member-cardlist',
+                                   kwargs={'slug': 'stein-gertrude'}))
+        self.assertTemplateUsed('people/member_cardlist.html')
+        self.assertTemplateUsed('snippets/breadcrumbs.html')
+        # first name used for page title
+        self.assertContains(response, member.firstname_last)
+        # links to main member page
+        self.assertContains(response, member.get_absolute_url())
+        cards = Canvas.objects.filter(
+            manifest__bibliography__account__persons__slug=member.slug)
+
+        for card in cards:
+            # include iiif images in src (1x twice for img and source)
+            self.assertContains(response, card.image.size(width=225), count=2)
+            self.assertContains(response, card.image.size(width=450), count=1)
+            dates = card.footnote_set.all().event_date_range()
+            if dates:
+                start, end = dates
+                # always show start year if set
+                self.assertContains(response, start.year)
+                # show end year if different
+                if start.year != end.year:
+                    self.assertContains(response, end.year)
+            else:
+                self.assertContains(response, 'Unknown')

--- a/mep/people/tests/test_views.py
+++ b/mep/people/tests/test_views.py
@@ -1184,7 +1184,7 @@ class TestMembershipGraphs(TestCase):
 
 
 class TestMemberCardList(TestCase):
-    fixtures = ['footnotes_gstein']
+    fixtures = ['footnotes_gstein', 'sample_people']
 
     def test_get_queryset(self):
         view = MemberCardList()
@@ -1258,3 +1258,8 @@ class TestMemberCardList(TestCase):
                     self.assertContains(response, end.year)
             else:
                 self.assertContains(response, 'Unknown')
+
+        # library member wih no cards
+        response = self.client.get(reverse('people:member-cardlist',
+                                   kwargs={'slug': 'gay'}))
+        self.assertContains(response, 'No cards available')

--- a/mep/people/urls.py
+++ b/mep/people/urls.py
@@ -6,6 +6,7 @@ from mep.people import views
 app_name = 'people'
 
 urlpatterns = [
+    # public member urls
     url(r'^members/$', views.MembersList.as_view(), name='members-list'),
     url(r'^members/graphs/$', views.MembershipGraphs.as_view(),
         name='member-graphs'),
@@ -13,6 +14,10 @@ urlpatterns = [
         name='member-detail'),
     url(r'^members/(?P<slug>[\w-]+)/activities/$',
         views.MembershipActivities.as_view(), name='membership-activities'),
+    url(r'^members/(?P<slug>[\w-]+)/cards/$',
+        views.MemberCardList.as_view(), name='member-cardlist'),
+
+    # admin urls
     url(r'^places/geonames/$', views.GeoNamesLookup.as_view(),
         name='geonames-lookup'),
     url(r'^places/geonames/country/$', views.GeoNamesLookup.as_view(),

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -382,7 +382,8 @@ class MemberCardList(LoginRequiredOr404Mixin, ListView, RdfViewMixin):
         # find all canvas objects for this person, via manifest
         # associated with lending card bibliography
         return super().get_queryset() \
-                      .filter(manifest__bibliography__account__persons__slug=self.kwargs['slug'])
+                      .filter(manifest__bibliography__account__persons__slug=self.kwargs['slug']) \
+                      .order_by('order')
 
     def get_absolute_url(self):
         '''Full URI for member card list page.'''

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -362,26 +362,30 @@ class MembershipActivities(LoginRequiredOr404Mixin, ListView, RdfViewMixin):
         return [
             ('Home', absolutize_url('/')),
             (MembersList.page_title, MembersList().get_absolute_url()),
-            (self.member.short_name, self.member.get_absolute_url()),
+            (self.member.short_name,
+             absolutize_url(self.member.get_absolute_url())),
             ('Membership Activities', self.get_absolute_url())
         ]
 
 
 class MemberCardList(LoginRequiredOr404Mixin, ListView, RdfViewMixin):
-    '''Card thumbnails for a single library member.'''
+    '''Card thumbnails for lending card associated with a single library
+    member.'''
     model = Canvas
     template_name = 'people/member_cardlist.html'
     context_object_name = 'cards'
-    # rdf_type = SCHEMA_ORG.ProfilePage
 
     def get_queryset(self):
+        # find the associated member; 404 if not found or not a library member
         self.member = get_object_or_404(Person.objects.library_members(),
                                         slug=self.kwargs['slug'])
+        # find all canvas objects for this person, via manifest
+        # associated with lending card bibliography
         return super().get_queryset() \
                       .filter(manifest__bibliography__account__persons__slug=self.kwargs['slug'])
 
     def get_absolute_url(self):
-        '''Get the full URI of this page.'''
+        '''Full URI for member card list page.'''
         return absolutize_url(reverse('people:member-cardlist',
                                       kwargs=self.kwargs))
 
@@ -390,7 +394,8 @@ class MemberCardList(LoginRequiredOr404Mixin, ListView, RdfViewMixin):
         return [
             ('Home', absolutize_url('/')),
             (MembersList.page_title, MembersList().get_absolute_url()),
-            (self.member.short_name, absolutize_url(self.member.get_absolute_url())),
+            (self.member.short_name,
+             absolutize_url(self.member.get_absolute_url())),
             ('Cards', self.get_absolute_url())
         ]
 

--- a/srcmedia/scss/cards/_result.scss
+++ b/srcmedia/scss/cards/_result.scss
@@ -3,6 +3,15 @@ ol.card-results {
     flex-wrap: wrap;
     padding-top: 2.15rem;
     border-top: 1px solid $white-two;
+
+    .member-cards & {
+        border-top: 0;
+
+        @media (min-width: $breakpoint-m + 1) {
+            padding-top: 3.8rem;
+        }
+    }
+
 }
 
 /* TODO: page nav controls spacing is not quite right.
@@ -21,19 +30,22 @@ ol.card-results {
 
     border-top: 0;
     width: $card-width;
-    /* space between cards: subtract three cards and divide remainder by 2 */;
-    margin-right: calc((100% - (#{$card-width} * 3)) / 2);
+
+    // on mobile, centered with one card per line
+    margin-right: auto;
+    margin-left: auto;
     margin-bottom: 2.8rem;
 
-    &:nth-child(3n+0) {
-        margin-right: 0;
-    }
+    // on tablet and desktop, three cards per line
+    @media (min-width: $breakpoint-s) {
+        & {
+            /* space between cards: subtract three cards and divide remainder by 2 */;
+            margin-left: 0;
+            margin-right: calc((100% - (#{$card-width} * 3)) / 2);
+        }
 
-    @media (max-width: $breakpoint-s) {
-        margin-right: auto;
-        margin-left: auto;
         &:nth-child(3n+0) {
-            margin-right: auto;
+            margin-right: 0;
         }
     }
 
@@ -42,8 +54,8 @@ ol.card-results {
     }
 
     @media (min-width: $breakpoint-s + 1) {
-        picture {
-            display: block;
+        img, source {
+            display: inline;
             height: 315px;
         }
     }
@@ -62,6 +74,7 @@ ol.card-results {
         font-family: $serif;
         font-size: 1.2rem;
     }
+
     .card-dates dd {
         font-family: $sans;
         font-size: 0.82rem;
@@ -69,6 +82,21 @@ ol.card-results {
     .card-dates.unknown  {
         color: $mid-grey;
     }
+
+
+    // adjust for individual member card thumbnails
+    .member-cards & {
+        margin-bottom: 1.75rem;
+
+        .card-dates {
+            // NOTE: picture element is taking up some space so this
+            // looks too big; not sure how to adjust
+            // padding-top: 0.95rem;
+        }
+
+    }
+
+
 
 }
 

--- a/srcmedia/scss/cards/_result.scss
+++ b/srcmedia/scss/cards/_result.scss
@@ -1,8 +1,12 @@
 ol.card-results {
-    display: flex;
-    flex-wrap: wrap;
     padding-top: 2.15rem;
     border-top: 1px solid $white-two;
+
+    // on tablet and desktop, three cards per line
+    @media (min-width: $breakpoint-s) {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+    }
 
     .member-cards & {
         border-top: 0;
@@ -30,24 +34,28 @@ ol.card-results {
 
     border-top: 0;
     width: $card-width;
-
-    // on mobile, centered with one card per line
-    margin-right: auto;
-    margin-left: auto;
     margin-bottom: 2.8rem;
 
     // on tablet and desktop, three cards per line
-    @media (min-width: $breakpoint-s) {
-        & {
-            /* space between cards: subtract three cards and divide remainder by 2 */;
-            margin-left: 0;
-            margin-right: calc((100% - (#{$card-width} * 3)) / 2);
+    @media (min-width: $breakpoint-s + 1) {
+        &:nth-child(3n+1) {
+            justify-self: start;
         }
-
+        &:nth-child(3n+2) {
+            justify-self: center;
+        }
         &:nth-child(3n+0) {
-            margin-right: 0;
+            justify-self: end;
         }
     }
+
+    @media (max-width: $breakpoint-s) {
+        // on mobile, centered with one card per line
+        margin-right: auto;
+        margin-left: auto;
+
+    }
+
 
     a:hover {
         border: 0;
@@ -87,6 +95,10 @@ ol.card-results {
     // adjust for individual member card thumbnails
     .member-cards & {
         margin-bottom: 1.75rem;
+
+        span.label {
+            @include sr-only;
+        }
 
         .card-dates {
             // NOTE: picture element is taking up some space so this

--- a/srcmedia/scss/cards/_result.scss
+++ b/srcmedia/scss/cards/_result.scss
@@ -18,6 +18,10 @@ ol.card-results {
 
 }
 
+.member-cards > div {   /* no cards available */
+    padding: 3.8rem 0;
+}
+
 /* TODO: page nav controls spacing is not quite right.
    Should align with edges of container on desktop (when there's room).
 .cards.sort-pages .outer {


### PR DESCRIPTION
View & template for displaying thumbnails of all cards associated with a member.

Includes:
- template tag for iiif image display so we can set size in the template
- footnote queryset with method to get date range based on events associated with those footnotes (i.e. dates for a single card)
- card list view & template; adapts card browse style since they are very similar