### PR TITLE
Search configuration for unicode folding and partial matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ after_success:
 - codecov
 after_script:
 - downloads/solr-${SOLR_VERSION}/bin/solr stop # shut down solr instance
+- rm -rf downloads/solr-${SOLR_VERSION}/
 notifications:
   slack:
     secure: BUUz68smbk73RdlfqKwCOL2vfQNvj3CcGqewYkrSsQ/YXz1EQ51pzR+krMAcnw8a5T/6zNTKzaRz4Z/kg+7EBn+fpFkGWG43NUekNSrCXkFnfK255Gp3RBYOCPyqengKPwxs90UdmjNzxqXe7xTxgL62mkW+mkJjl9l58/xpnzMOC3+0+EDHoXrrWKiQeSYkvqkOmEErsoWzS8HELphYKZvDdQpoFhlqB8Jsh97Wmi+y8bS47BmvVxKcHFmoKUIsjS7xQapvrXllfLEn1ws5TxSRp0/1kKAUaL9NRC8xpGOrGGreWOaSzVt3q4X8HmzoieCWJPQDPNJSFwQ56VF5INVbpT5W+OX0JwV+lJB1Iy7VQWt4bwzilX+gvvW76UcHedQrNnITx6wEqRtlnKvhm7jwAv2DTrmvOK8t1A3cRhtfkahG9M3OpYdNxrs3ROfftMgikVpjxSA1OqqFj22TVl/pFYjP+cvNQX+JICo1eMKZCw6zf/Ei9p5RYZkqywZsY5eQbdYC2pBpFly5DEioxjhqfw0sUOGOiAWId8HeAZmbqi1cKrUtSA2sfSWzGjSOF0n/IrfYTr/ux64bopbwX1natqAi+7XsD9dAQA1AQ12QmpOvBYrH8ThiqCLc14m9+7Vygmeo9+BPk8H9Q312vlsHRPrs/ZOhRsKEghwBa4o=

--- a/DEPLOYNOTES.rst
+++ b/DEPLOYNOTES.rst
@@ -3,6 +3,22 @@
 Deploy and Upgrade notes
 ========================
 
+
+
+0.23
+----
+
+* Unicode folding and partial name searching require an update to the
+  Solr configuration.
+
+  Copy all files under `solr_conf/conf/` to your configured Solr configset.
+
+  Then update the schema and reindex::
+
+    python manage.py solr_schema
+    python manage.py index -i person
+
+
 0.23
 ----
 

--- a/mep/common/solr.py
+++ b/mep/common/solr.py
@@ -16,6 +16,6 @@ class SolrSchema(schema.SolrSchema):
         # _s_en = string version of sort name for sort/facet
         # _txt_gen = unicode/case folding version for searching / sorting
         # _ngram = ngram tokenized version for partial matching
-        'sort_name_t': ['sort_name_sort_s_en', 'name_txt_gen', 'name_ngram'],
+        'sort_name_t': ['name_txt_gen', 'name_ngram'],
         'name_t': ['name_txt_gen', 'name_ngram']
     }

--- a/mep/common/solr.py
+++ b/mep/common/solr.py
@@ -1,12 +1,17 @@
 from parasolr import schema
 
 
+class SortField(schema.SolrTypedField):
+    '''Field for sorting: single keyword with case & unicode folding'''
+    field_type = 'string_en'
+
+
 class SolrSchema(schema.SolrSchema):
     '''Solr Schema declaration.'''
 
     item_type = schema.SolrStringField()
-
     nationality = schema.SolrStringField(multivalued=True)
+    sortable_name = SortField(multivalued=False)
 
     # relying on dynamic fields for everything else; see index data
     # methods and solr queryset aliases for specifics

--- a/mep/common/solr.py
+++ b/mep/common/solr.py
@@ -13,12 +13,9 @@ class SolrSchema(schema.SolrSchema):
 
     #: copy fields for facets and variant search options
     copy_fields = {
-        # string version of sort name for sort/facet
-        'sort_name_t': 'sort_name_sort_s_en',
-        # unicode/case folding version of names for searching
-        'name_t': 'name_txt_gen',
-        'sort_name_t': 'name_txt_gen',
-        # ngram version of names for searching
-        'name_t': 'name_ngram',
-        'sort_name_t': 'name_ngram',
+        # _s_en = string version of sort name for sort/facet
+        # _txt_gen = unicode/case folding version for searching / sorting
+        # _ngram = ngram tokenized version for partial matching
+        'sort_name_t': ['sort_name_sort_s_en', 'name_txt_gen', 'name_ngram'],
+        'name_t': ['name_txt_gen', 'name_ngram']
     }

--- a/mep/common/solr.py
+++ b/mep/common/solr.py
@@ -16,6 +16,6 @@ class SolrSchema(schema.SolrSchema):
         # _s_en = string version of sort name for sort/facet
         # _txt_gen = unicode/case folding version for searching / sorting
         # _ngram = ngram tokenized version for partial matching
-        'sort_name_t': ['name_ngram', 'sort_name_sort_s_en'],
+        'sort_name_t': 'name_ngram',
         'name_t': 'name_ngram'
     }

--- a/mep/common/solr.py
+++ b/mep/common/solr.py
@@ -16,6 +16,6 @@ class SolrSchema(schema.SolrSchema):
         # _s_en = string version of sort name for sort/facet
         # _txt_gen = unicode/case folding version for searching / sorting
         # _ngram = ngram tokenized version for partial matching
-        'sort_name_t': ['name_txt_gen', 'name_ngram'],
-        'name_t': ['name_txt_gen', 'name_ngram']
+        'sort_name_t': ['name_ngram', 'sort_name_sort_s_en'],
+        'name_t': 'name_ngram'
     }

--- a/mep/common/solr.py
+++ b/mep/common/solr.py
@@ -8,4 +8,17 @@ class SolrSchema(schema.SolrSchema):
 
     nationality = schema.SolrStringField(multivalued=True)
 
-    # relying on dynamic fields for now
+    # relying on dynamic fields for everything else; see index data
+    # methods and solr queryset aliases for specifics
+
+    #: copy fields for facets and variant search options
+    copy_fields = {
+        # string version of sort name for sort/facet
+        'sort_name_t': 'sort_name_sort_s_en',
+        # unicode/case folding version of names for searching
+        'name_t': 'name_txt_gen',
+        'sort_name_t': 'name_txt_gen',
+        # ngram version of names for searching
+        'name_t': 'name_ngram',
+        'sort_name_t': 'name_ngram',
+    }

--- a/mep/common/tests.py
+++ b/mep/common/tests.py
@@ -287,6 +287,14 @@ def test_alpha_pagelabels():
     # first two letters of first and last titles is enough
     assert labels[1] == '%s - %s' % (titles[0][:2], titles[-1][:2])
 
+    # case-insensitive
+    titles = ['Core', 'd\'Aricourt', 'D\'Assay', 'Estaing']
+    items = [Item(t) for t in titles]
+    paginator = Paginator(items, per_page=2)
+    labels = alpha_pagelabels(paginator, items, lambda x: getattr(x, 'title'))
+    assert labels[1].endswith("d'Ar")
+    assert labels[2].startswith("D'As")
+
     # returns empty response if no items
     paginator = Paginator([], per_page=20)
     assert not alpha_pagelabels(paginator, [], lambda x: getattr(x, 'title'))

--- a/mep/common/utils.py
+++ b/mep/common/utils.py
@@ -91,7 +91,11 @@ def alpha_pagelabels(paginator, objects, attr_meth):
             abbr += char   # or abbr = label[:j]
             # if abbreviation is different from neighboring labels
             # at the current length, then use it
-            if abbr not in (next_label[:j], prev_label[:j]):
+            # - compare case-insensitively
+            # NOTE: should possibly ignore trailing punctuation here...
+            # possible to get "Gray" / "Gray,"
+            if abbr.lower() not in (next_label[:j].lower(),
+                                    prev_label[:j].lower()):
                 break
             # if we don't break before the loop finishes, use
             # the whole label

--- a/mep/people/models.py
+++ b/mep/people/models.py
@@ -614,7 +614,7 @@ class Person(Notable, DateRange, ModelIndexable):
             # text version of sort name for search and display
             'sort_name_t': self.sort_name,
             # string version of sort name for sort/facet
-            'sort_name_sort_s': self.sort_name,
+            'sort_name_sort_s_en': self.sort_name,
             'birth_year_i': self.birth_year,
             'death_year_i': self.death_year,
             'has_card_b': self.has_card(),

--- a/mep/people/models.py
+++ b/mep/people/models.py
@@ -613,7 +613,7 @@ class Person(Notable, DateRange, ModelIndexable):
             'slug_s': self.slug,
             # text version of sort name for search and display
             'sort_name_t': self.sort_name,
-            'sort_name_sort_s_en': self.sort_name,
+            'sortable_name': self.sort_name,
             'birth_year_i': self.birth_year,
             'death_year_i': self.death_year,
             'has_card_b': self.has_card(),

--- a/mep/people/models.py
+++ b/mep/people/models.py
@@ -613,8 +613,6 @@ class Person(Notable, DateRange, ModelIndexable):
             'slug_s': self.slug,
             # text version of sort name for search and display
             'sort_name_t': self.sort_name,
-            # string version of sort name for sort/facet
-            'sort_name_sort_s_en': self.sort_name,
             'birth_year_i': self.birth_year,
             'death_year_i': self.death_year,
             'has_card_b': self.has_card(),

--- a/mep/people/models.py
+++ b/mep/people/models.py
@@ -613,7 +613,6 @@ class Person(Notable, DateRange, ModelIndexable):
             'slug_s': self.slug,
             # text version of sort name for search and display
             'sort_name_t': self.sort_name,
-            'sort_name_sort_s_en': self.sort_name,
             'birth_year_i': self.birth_year,
             'death_year_i': self.death_year,
             'has_card_b': self.has_card(),

--- a/mep/people/models.py
+++ b/mep/people/models.py
@@ -613,6 +613,7 @@ class Person(Notable, DateRange, ModelIndexable):
             'slug_s': self.slug,
             # text version of sort name for search and display
             'sort_name_t': self.sort_name,
+            'sort_name_sort_s_en': self.sort_name,
             'birth_year_i': self.birth_year,
             'death_year_i': self.death_year,
             'has_card_b': self.has_card(),

--- a/mep/people/queryset.py
+++ b/mep/people/queryset.py
@@ -12,7 +12,7 @@ class PersonSolrQuerySet(AliasedSolrQuerySet):
     field_aliases = {
         'name': 'name_t',
         'sort_name': 'sort_name_t',
-        'sort_name_sort': 'sort_name_sort_s_en',
+        'sort_name_sort': 'sortable_name',
         'birth_year': 'birth_year_i',
         'death_year': 'death_year_i',
         'account_start': 'account_start_i',

--- a/mep/people/queryset.py
+++ b/mep/people/queryset.py
@@ -12,6 +12,7 @@ class PersonSolrQuerySet(AliasedSolrQuerySet):
     field_aliases = {
         'name': 'name_t',
         'sort_name': 'sort_name_t',
+        'sort_name_sort': 'sort_name_sort_s_en',
         'birth_year': 'birth_year_i',
         'death_year': 'death_year_i',
         'account_start': 'account_start_i',

--- a/mep/people/templates/people/member_list.html
+++ b/mep/people/templates/people/member_list.html
@@ -63,7 +63,7 @@
             </div>
             <input type="submit" value="submit"/>
         </fieldset>
-        <output class="total-results" id="total">{{ members.count|intcomma }} total result{{ members.count|pluralize }}</output>
+        <output class="total-results" id="total">{% if error_message %}{{ error_message }}{% else %}{{ members.count|intcomma }} total result{{ members.count|pluralize }}{% endif %}</output>
     </form>
 </div>
 <div class="upper-labels"> {# only shown on mobile & tablet before the user scrolls down #}

--- a/mep/people/tests/test_models.py
+++ b/mep/people/tests/test_models.py
@@ -311,6 +311,7 @@ class TestPerson(TestCase):
         assert index_data['slug_s'] == pers.slug
         assert index_data['name_t'] == pers.name
         assert index_data['sort_name_t'] == pers.sort_name
+        assert index_data['sort_name_sort_s_en'] == pers.sort_name
         assert index_data['birth_year_i'] == pers.birth_year
         assert index_data['death_year_i'] == pers.death_year
         # account dates and gender should not be set

--- a/mep/people/tests/test_models.py
+++ b/mep/people/tests/test_models.py
@@ -311,7 +311,6 @@ class TestPerson(TestCase):
         assert index_data['slug_s'] == pers.slug
         assert index_data['name_t'] == pers.name
         assert index_data['sort_name_t'] == pers.sort_name
-        assert index_data['sort_name_sort_s_en'] == pers.sort_name
         assert index_data['birth_year_i'] == pers.birth_year
         assert index_data['death_year_i'] == pers.death_year
         # account dates and gender should not be set

--- a/mep/people/tests/test_views.py
+++ b/mep/people/tests/test_views.py
@@ -735,6 +735,23 @@ class TestMembersListView(TestCase):
 
         # TODO: not sure how to test pagination/multiple pages
 
+        # test partial match
+        response = self.client.get(self.members_url, {'query': "heming"})
+        self.assertContains(response, "Hemingway, Ernest")
+
+        # test accent folding
+        rene_account = Account.objects.create()
+        rene = Person.objects.create(sort_name='Chambrillac, René', slug='rene')
+        rene_account.persons.add(rene)
+        Person.index_items([rene])
+        time.sleep(1)
+        # with accent
+        response = self.client.get(self.members_url, {'query': "rené"})
+        self.assertContains(response, rene.sort_name)
+        # without accent
+        response = self.client.get(self.members_url, {'query': "rene"})
+        self.assertContains(response, rene.sort_name)
+
     def test_get_page_labels(self):
         view = MembersList()
         # patch out get_form

--- a/mep/people/tests/test_views.py
+++ b/mep/people/tests/test_views.py
@@ -753,7 +753,8 @@ class TestMembersListView(TestCase):
             # first arg is paginator
             assert alpha_pagelabels_args[0] == paginator
             # second arg is queryset with revised field list
-            assert alpha_pagelabels_args[1] == view.queryset.only.return_value
+            assert alpha_pagelabels_args[1] == \
+                view.queryset.only.return_value.get_results.return_value
             # third arg is a lambda
             assert isinstance(alpha_pagelabels_args[2], LambdaType)
 

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -177,16 +177,26 @@ class MembersList(LabeledPagesMixin, ListView, FormMixin,
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        facets = self.object_list.get_facets()['facet_fields']
-        # convert arrondissement numbers into ordinals for display
-        facets['arrondissement'] = OrderedDict([
-            (ordinal(val), count)
-            for val, count in facets['arrondissement'].items()
-        ])
-        self._form.set_choices_from_facets(facets)
+        facets = self.object_list.get_facets().get('facet_fields', None)
+        error_message = ''
+        # facets are not set if query errors
+        if facets:
+            # convert arrondissement numbers into ordinals for display
+            facets['arrondissement'] = OrderedDict([
+                (ordinal(val), count)
+                for val, count in facets['arrondissement'].items()
+            ])
+            self._form.set_choices_from_facets(facets)
+        else:
+            # if facets are not set, the query errored
+            error_message = 'Something went wrong'
+
+        # if facets are not set, add an error message to display in context?
+        # (this means that something went wrong with the query...)
         context.update({
             'page_title': self.page_title,
-            'page_description': self.page_description
+            'page_description': self.page_description,
+            'error_message': error_message
         })
         return context
 

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -203,7 +203,10 @@ class MembersList(LoginRequiredOr404Mixin, LabeledPagesMixin, ListView,
             return super().get_page_labels(paginator)
 
         # otherwise, when sorting by alpha, generate alpha page labels
-        pagination_qs = self.queryset.only('sort_name')
+        # Only return sort name; get everything at once to avoid
+        # hitting Solr for each page / item.
+        pagination_qs = self.queryset.only('sort_name') \
+                                     .get_results(rows=100000)
         alpha_labels = alpha_pagelabels(paginator, pagination_qs,
                                         lambda x: x['sort_name'][0])
         # alpha labels is a dict; use items to return list of tuples

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -121,7 +121,7 @@ class MembersList(LoginRequiredOr404Mixin, LabeledPagesMixin, ListView,
     # map form sort to solr sort field
     solr_sort = {
         'relevance': '-score',
-        'name': 'sort_name_sort_s'
+        'name': 'sort_name_sort'
     }
 
     def get_queryset(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,9 @@ django-apptemplates
 py-flags
 django-tabular-export
 django-webpack-loader
-parasolr>=0.5
+# use bugfix branch to see if sheds more light on Solr field error
+# parasolr>=0.5
+git+https://github.com/Princeton-CDH/parasolr@bugfix/handle-empty-result#egg=parasolr
 django-widget-tweaks
 pymarc
 progressbar2

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -456,6 +456,7 @@
     <!-- custom string-like sort field that ignores accents and case; using text because
          solr string field does not allow analyzers -->
     <dynamicField name="*_s_en" type="string_en" indexed="true" stored="true" />
+    <field name="sortable_name" type="string_en" indexed="true" stored="true" multiValued="false"/>
     <fieldType name="string_en" class="solr.TextField" sortMissingLast="true" multiValued="false">
        <analyzer type="index">
             <!-- treat entire field as a single token -->

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -373,6 +373,7 @@
          (empty by default), down cases, and performs Unicode normalizatin.
          At query time only, it also applies synonyms.
 	  -->
+    <dynamicField name="*_txt_gen" type="text_general" indexed="true" stored="true" multiValued="true"/>
     <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100" multiValued="true">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>
@@ -381,6 +382,7 @@
         <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
         <filter class="solr.FlattenGraphFilterFactory"/>
         -->
+        <filter class="solr.ICUFoldingFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
       <analyzer type="query">
@@ -388,6 +390,23 @@
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.ICUFoldingFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+   <!-- A text field with ngram filtering for partial word matching -->
+    <dynamicField name="*_ngram" type="text_ngram" indexed="true"  stored="false" multiValued="true"/>
+    <fieldType name="text_ngram" class="solr.TextField" positionIncrementGap="100">
+      <!-- apply ngram on index only, not on query -->
+      <analyzer type="index">
+         <tokenizer class="solr.StandardTokenizerFactory"/>
+         <!-- apply unicode normalization and case folding -->
+         <filter class="solr.ICUFoldingFilterFactory"/>
+        <filter class="solr.NGramFilterFactory" minGramSize="3" maxGramSize="8"/>
+      </analyzer>
+      <analyzer type="query">
+         <tokenizer class="solr.StandardTokenizerFactory"/>
+         <!-- apply unicode normalization and case folding -->
+         <filter class="solr.ICUFoldingFilterFactory"/>
       </analyzer>
     </fieldType>
 

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -370,7 +370,7 @@
     <!-- A general text field that has reasonable, generic
          cross-language defaults: it tokenizes with StandardTokenizer,
          removes stop words from case-insensitive "stopwords.txt"
-         (empty by default), down cases, and performs Unicode normalizatin.
+         (empty by default), down cases, and performs Unicode normalization.
          At query time only, it also applies synonyms.
 	  -->
     <dynamicField name="*_txt_gen" type="text_general" indexed="true" stored="true" multiValued="true"/>

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -435,6 +435,20 @@
       </analyzer>
     </fieldType>
 
+    <!-- custom string-like sort field that ignores accents and case; using text because
+         solr string field does not allow analyzers -->
+    <dynamicField name="*_s_en" type="string_en" indexed="true" stored="true" multiValued="false" />
+    <fieldType name="string_en" class="solr.TextField" sortMissingLast="true">
+       <analyzer type="index">
+            <!-- treat entire field as a single token -->
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <!-- apply unicode normalization and case folding -->
+          <filter class="solr.ICUFoldingFilterFactory"/>
+       </analyzer>
+       <!-- no query analyzer; only expected to be used for sorting, not
+            querying or faceting -->
+    </fieldType>
+
     <!-- A text field with defaults appropriate for English, plus
          aggressive word-splitting and autophrase features enabled.
          This field is just like text_en, except it adds

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -16,10 +16,10 @@
  limitations under the License.
 -->
 
-<!--  
+<!--
  This is the Solr schema file. This file should be named "schema.xml" and
  should be in the conf directory under the solr home
- (i.e. ./solr/conf/schema.xml by default) 
+ (i.e. ./solr/conf/schema.xml by default)
  or located where the classloader for the Solr webapp can find it.
 
  This example schema is the recommended starting point for users.
@@ -47,34 +47,34 @@
 
 <schema name="example-basic" version="1.6">
     <!-- attribute "name" is the name of this schema and is only used for display purposes.
-       version="x.y" is Solr's version number for the schema syntax and 
+       version="x.y" is Solr's version number for the schema syntax and
        semantics.  It should not normally be changed by applications.
 
-       1.0: multiValued attribute did not exist, all fields are multiValued 
+       1.0: multiValued attribute did not exist, all fields are multiValued
             by nature
-       1.1: multiValued attribute introduced, false by default 
-       1.2: omitTermFreqAndPositions attribute introduced, true by default 
+       1.1: multiValued attribute introduced, false by default
+       1.2: omitTermFreqAndPositions attribute introduced, true by default
             except for text fields.
        1.3: removed optional field compress feature
        1.4: autoGeneratePhraseQueries attribute introduced to drive QueryParser
-            behavior when a single string produces multiple tokens.  Defaults 
+            behavior when a single string produces multiple tokens.  Defaults
             to off for version >= 1.4
-       1.5: omitNorms defaults to true for primitive field types 
+       1.5: omitNorms defaults to true for primitive field types
             (int, float, boolean, string...)
        1.6: useDocValuesAsStored defaults to true.
     -->
 
     <!-- Valid attributes for fields:
      name: mandatory - the name for the field
-     type: mandatory - the name of a field type from the 
+     type: mandatory - the name of a field type from the
        fieldTypes section
      indexed: true if this field should be indexed (searchable or sortable)
      stored: true if this field should be retrievable
      docValues: true if this field should have doc values. Doc values are
-       useful (required, if you are using *Point fields) for faceting, 
-       grouping, sorting and function queries. Doc values will make the index 
-       faster to load, more NRT-friendly and more memory-efficient. 
-       They however come with some limitations: they are currently only 
+       useful (required, if you are using *Point fields) for faceting,
+       grouping, sorting and function queries. Doc values will make the index
+       faster to load, more NRT-friendly and more memory-efficient.
+       They however come with some limitations: they are currently only
        supported by StrField, UUIDField, all Trie*Fields and *PointFields,
        and depending on the field type, they might require the field to be
        single-valued, be required or have a default value (check the
@@ -89,9 +89,9 @@
        given field.
        When using MoreLikeThis, fields used for similarity should be
        stored for best performance.
-     termPositions: Store position information with the term vector.  
+     termPositions: Store position information with the term vector.
        This will increase storage costs.
-     termOffsets: Store offset information with the term vector. This 
+     termOffsets: Store offset information with the term vector. This
        will increase storage costs.
      required: The field is required.  It will throw an error if the
        value does not exist
@@ -106,14 +106,14 @@
       trailing underscores (e.g. _version_) are reserved.
     -->
 
-    <!-- In this data_driven_schema_configs configset, only three fields are pre-declared: 
+    <!-- In this data_driven_schema_configs configset, only three fields are pre-declared:
          id, _version_, and _text_.  All other fields will be type guessed and added via the
-         "add-unknown-fields-to-the-schema" update request processor chain declared 
+         "add-unknown-fields-to-the-schema" update request processor chain declared
          in solrconfig.xml.
-         
-         Note that many dynamic fields are also defined - you can use them to specify a 
+
+         Note that many dynamic fields are also defined - you can use them to specify a
          field's type via field naming conventions - see below.
-  
+
          WARNING: The _text_ catch-all field will significantly increase your index size.
          If you don't need it, consider removing it and the corresponding copyField directive.
     -->
@@ -128,11 +128,11 @@
     <!-- <copyField source="*" dest="_text_"/> -->
 
     <!-- Dynamic field definitions allow using convention over configuration
-       for fields via the specification of patterns to match field names. 
+       for fields via the specification of patterns to match field names.
        EXAMPLE:  name="*_i" will match any field ending in _i (like myid_i, z_i)
        RESTRICTION: the glob-like pattern in the name attribute must have
        a "*" only at the start or the end.  -->
-   
+
     <dynamicField name="*_i"  type="int"    indexed="true"  stored="true"/>
     <dynamicField name="*_is" type="ints"    indexed="true"  stored="true"/>
     <dynamicField name="*_s"  type="string"  indexed="true"  stored="true" />
@@ -152,7 +152,7 @@
     <dynamicField name="*_dts" type="date"    indexed="true"  stored="true" multiValued="true"/>
     <dynamicField name="*_p"  type="location" indexed="true" stored="true"/>
     <dynamicField name="*_srpt"  type="location_rpt" indexed="true" stored="true"/>
-    
+
     <!-- KD-tree (point) numerics -->
     <dynamicField name="*_pi" type="pint"    indexed="true"  stored="true"/>
     <dynamicField name="*_pis" type="pints"    indexed="true"  stored="true"/>
@@ -184,13 +184,13 @@
 
     <dynamicField name="random_*" type="random" />
 
-    <!-- uncomment the following to ignore any fields that don't already match an existing 
-        field name or dynamic field, rather than reporting them as an error. 
-        alternately, change the type="ignored" to some other type e.g. "text" if you want 
-        unknown fields indexed and/or stored by default 
-        
+    <!-- uncomment the following to ignore any fields that don't already match an existing
+        field name or dynamic field, rather than reporting them as an error.
+        alternately, change the type="ignored" to some other type e.g. "text" if you want
+        unknown fields indexed and/or stored by default
+
         NB: use of "*" dynamic fields will disable field type guessing and adding
-        unknown fields to the schema. --> 
+        unknown fields to the schema. -->
     <!--dynamicField name="*" type="ignored" multiValued="true" /-->
 
     <!-- Field to use to determine and enforce document uniqueness.
@@ -240,7 +240,7 @@
          then default lucene sorting will be used which places docs without the
          field first in an ascending sort and last in a descending sort.
     -->
-    
+
     <!--
       Numeric field types that index values using KD-trees. *Point fields are faster and more efficient than Trie* fields both, at
       search time and at index time, but some features are still not supported.
@@ -250,14 +250,14 @@
     <fieldType name="pfloat" class="solr.FloatPointField" docValues="true"/>
     <fieldType name="plong" class="solr.LongPointField" docValues="true"/>
     <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
-    
+
     <fieldType name="pints" class="solr.IntPointField" docValues="true" multiValued="true"/>
     <fieldType name="pfloats" class="solr.FloatPointField" docValues="true" multiValued="true"/>
     <fieldType name="plongs" class="solr.LongPointField" docValues="true" multiValued="true"/>
     <fieldType name="pdoubles" class="solr.DoublePointField" docValues="true" multiValued="true"/>
 
     <!--
-      Default numeric field types. For faster range queries, consider *PointFields (pint/pfloat/plong/pdouble), or the 
+      Default numeric field types. For faster range queries, consider *PointFields (pint/pfloat/plong/pdouble), or the
       tint/tfloat/tlong/tdouble types.
     -->
     <fieldType name="int" class="solr.TrieIntField" docValues="true" precisionStep="0" positionIncrementGap="0"/>
@@ -279,14 +279,14 @@
      Smaller precisionStep values (specified in bits) will lead to more tokens
      indexed per value, slightly larger index size, and faster range queries.
      A precisionStep of 0 disables indexing at different precision levels.
-     
+
      Consider using pint/pfloat/plong/pdouble instead of Trie* fields if possible
     -->
     <fieldType name="tint" class="solr.TrieIntField" docValues="true" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tfloat" class="solr.TrieFloatField" docValues="true" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tlong" class="solr.TrieLongField" docValues="true" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tdouble" class="solr.TrieDoubleField" docValues="true" precisionStep="8" positionIncrementGap="0"/>
-    
+
     <fieldType name="tints" class="solr.TrieIntField" docValues="true" precisionStep="8" positionIncrementGap="0" multiValued="true"/>
     <fieldType name="tfloats" class="solr.TrieFloatField" docValues="true" precisionStep="8" positionIncrementGap="0" multiValued="true"/>
     <fieldType name="tlongs" class="solr.TrieLongField" docValues="true" precisionStep="8" positionIncrementGap="0" multiValued="true"/>
@@ -294,7 +294,7 @@
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
          is a more restricted form of the canonical representation of dateTime
-         http://www.w3.org/TR/xmlschema-2/#dateTime    
+         http://www.w3.org/TR/xmlschema-2/#dateTime
          The trailing "Z" designates UTC time and is mandatory.
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
          All other components are mandatory.
@@ -309,13 +309,13 @@
                NOW/DAY+6MONTHS+3DAYS
                   ... 6 months and 3 days in the future from the start of
                       the current day
-                      
+
          Consult the TrieDateField javadocs for more information.
       -->
     <!-- KD-tree versions of date fields -->
     <fieldType name="pdate" class="solr.DatePointField" docValues="true"/>
     <fieldType name="pdates" class="solr.DatePointField" docValues="true" multiValued="true"/>
-    
+
     <fieldType name="date" class="solr.TrieDateField" docValues="true" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="dates" class="solr.TrieDateField" docValues="true" precisionStep="0" positionIncrementGap="0" multiValued="true"/>
 
@@ -328,11 +328,11 @@
 
     <!-- The "RandomSortField" is not used to store or search any
          data.  You can declare fields of this type it in your schema
-         to generate pseudo-random orderings of your docs for sorting 
+         to generate pseudo-random orderings of your docs for sorting
          or function purposes.  The ordering is generated based on the field
          name and the version of the index. As long as the index version
          remains unchanged, and the same field name is reused,
-         the ordering of the docs will be consistent.  
+         the ordering of the docs will be consistent.
          If you want different psuedo-random orderings of documents,
          for the same version of the index, use a dynamicField and
          change the field name in the request.
@@ -369,9 +369,9 @@
 
     <!-- A general text field that has reasonable, generic
          cross-language defaults: it tokenizes with StandardTokenizer,
-	       removes stop words from case-insensitive "stopwords.txt"
-	       (empty by default), and down cases.  At query time only, it
-	       also applies synonyms.
+         removes stop words from case-insensitive "stopwords.txt"
+         (empty by default), down cases, and performs Unicode normalizatin.
+         At query time only, it also applies synonyms.
 	  -->
     <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100" multiValued="true">
       <analyzer type="index">
@@ -387,7 +387,7 @@
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.ICUFoldingFilterFactory"/>
       </analyzer>
     </fieldType>
 
@@ -545,7 +545,7 @@
       </analyzer>
     </fieldType>
 
-    <!-- 
+    <!--
       Example of using PathHierarchyTokenizerFactory at index time, so
       queries for paths match documents at that path, or in descendent paths
     -->
@@ -574,12 +574,12 @@
     </fieldType>
 
     <!-- since fields of this type are by default not stored or indexed,
-         any data added to them will be ignored outright.  --> 
+         any data added to them will be ignored outright.  -->
     <fieldType name="ignored" stored="false" indexed="false" docValues="false" multiValued="true" class="solr.StrField" />
 
     <!-- This point type indexes the coordinates as separate fields (subFields)
       If subFieldType is defined, it references a type, and a dynamic field
-      definition is created matching *___<typename>.  Alternately, if 
+      definition is created matching *___<typename>.  Alternately, if
       subFieldSuffix is defined, that is used to create the subFields.
       Example: if subFieldType="double", then the coordinates would be
         indexed in fields myloc_0___double,myloc_1___double.
@@ -613,7 +613,7 @@
                              refreshInterval: Number of minutes between each rates fetch (default: 1440, min: 60)
     -->
     <fieldType name="currency" class="solr.CurrencyField" precisionStep="8" defaultCurrency="USD" currencyConfig="currency.xml" />
-             
+
 
 
     <!-- some examples for different languages (generally ordered by ISO code) -->
@@ -621,7 +621,7 @@
     <!-- Arabic -->
     <dynamicField name="*_txt_ar" type="text_ar"  indexed="true"  stored="true"/>
     <fieldType name="text_ar" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- for any non-arabic -->
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -635,27 +635,27 @@
     <!-- Bulgarian -->
     <dynamicField name="*_txt_bg" type="text_bg"  indexed="true"  stored="true"/>
     <fieldType name="text_bg" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/> 
+      <analyzer>
+        <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_bg.txt" /> 
-        <filter class="solr.BulgarianStemFilterFactory"/>       
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_bg.txt" />
+        <filter class="solr.BulgarianStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Catalan -->
     <dynamicField name="*_txt_ca" type="text_ca"  indexed="true"  stored="true"/>
     <fieldType name="text_ca" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- removes l', etc -->
         <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ca.txt"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ca.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Catalan"/>       
+        <filter class="solr.SnowballPorterFilterFactory" language="Catalan"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- CJK bigram (see text_ja for a Japanese configuration using morphological analysis) -->
     <dynamicField name="*_txt_cjk" type="text_cjk"  indexed="true"  stored="true"/>
     <fieldType name="text_cjk" class="solr.TextField" positionIncrementGap="100">
@@ -672,29 +672,29 @@
     <!-- Czech -->
     <dynamicField name="*_txt_cz" type="text_cz"  indexed="true"  stored="true"/>
     <fieldType name="text_cz" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_cz.txt" />
-        <filter class="solr.CzechStemFilterFactory"/>       
+        <filter class="solr.CzechStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Danish -->
     <dynamicField name="*_txt_da" type="text_da"  indexed="true"  stored="true"/>
     <fieldType name="text_da" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_da.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Danish"/>       
+        <filter class="solr.SnowballPorterFilterFactory" language="Danish"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- German -->
     <dynamicField name="*_txt_de" type="text_de"  indexed="true"  stored="true"/>
     <fieldType name="text_de" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_de.txt" format="snowball" />
@@ -704,11 +704,11 @@
         <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="German2"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Greek -->
     <dynamicField name="*_txt_el" type="text_el"  indexed="true"  stored="true"/>
     <fieldType name="text_el" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- greek specific lowercase for sigma -->
         <filter class="solr.GreekLowerCaseFilterFactory"/>
@@ -716,11 +716,11 @@
         <filter class="solr.GreekStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Spanish -->
     <dynamicField name="*_txt_es" type="text_es"  indexed="true"  stored="true"/>
     <fieldType name="text_es" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_es.txt" format="snowball" />
@@ -728,18 +728,18 @@
         <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Spanish"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Basque -->
     <dynamicField name="*_txt_eu" type="text_eu"  indexed="true"  stored="true"/>
     <fieldType name="text_eu" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_eu.txt" />
         <filter class="solr.SnowballPorterFilterFactory" language="Basque"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Persian -->
     <dynamicField name="*_txt_fa" type="text_fa"  indexed="true"  stored="true"/>
     <fieldType name="text_fa" class="solr.TextField" positionIncrementGap="100">
@@ -753,11 +753,11 @@
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fa.txt" />
       </analyzer>
     </fieldType>
-    
+
     <!-- Finnish -->
     <dynamicField name="*_txt_fi" type="text_fi"  indexed="true"  stored="true"/>
     <fieldType name="text_fi" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fi.txt" format="snowball" />
@@ -765,11 +765,11 @@
         <!-- less aggressive: <filter class="solr.FinnishLightStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- French -->
     <dynamicField name="*_txt_fr" type="text_fr"  indexed="true"  stored="true"/>
     <fieldType name="text_fr" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- removes l', etc -->
         <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_fr.txt"/>
@@ -780,11 +780,11 @@
         <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="French"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Irish -->
     <dynamicField name="*_txt_ga" type="text_ga"  indexed="true"  stored="true"/>
     <fieldType name="text_ga" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- removes d', etc -->
         <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ga.txt"/>
@@ -795,11 +795,11 @@
         <filter class="solr.SnowballPorterFilterFactory" language="Irish"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Galician -->
     <dynamicField name="*_txt_gl" type="text_gl"  indexed="true"  stored="true"/>
     <fieldType name="text_gl" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_gl.txt" />
@@ -807,11 +807,11 @@
         <!-- less aggressive: <filter class="solr.GalicianMinimalStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Hindi -->
     <dynamicField name="*_txt_hi" type="text_hi"  indexed="true"  stored="true"/>
     <fieldType name="text_hi" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <!-- normalizes unicode representation -->
@@ -822,34 +822,34 @@
         <filter class="solr.HindiStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Hungarian -->
     <dynamicField name="*_txt_hu" type="text_hu"  indexed="true"  stored="true"/>
     <fieldType name="text_hu" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hu.txt" format="snowball" />
         <filter class="solr.SnowballPorterFilterFactory" language="Hungarian"/>
-        <!-- less aggressive: <filter class="solr.HungarianLightStemFilterFactory"/> -->   
+        <!-- less aggressive: <filter class="solr.HungarianLightStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Armenian -->
     <dynamicField name="*_txt_hy" type="text_hy"  indexed="true"  stored="true"/>
     <fieldType name="text_hy" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hy.txt" />
         <filter class="solr.SnowballPorterFilterFactory" language="Armenian"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Indonesian -->
     <dynamicField name="*_txt_id" type="text_id"  indexed="true"  stored="true"/>
     <fieldType name="text_id" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_id.txt" />
@@ -857,11 +857,11 @@
         <filter class="solr.IndonesianStemFilterFactory" stemDerivational="true"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Italian -->
   <dynamicField name="*_txt_it" type="text_it"  indexed="true"  stored="true"/>
   <fieldType name="text_it" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- removes l', etc -->
         <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_it.txt"/>
@@ -871,7 +871,7 @@
         <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Italian"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Japanese using morphological analysis (see text_cjk for a configuration using bigramming)
 
          NOTE: If you want to optimize search for precision, use default operator AND in your request
@@ -924,22 +924,22 @@
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Latvian -->
     <dynamicField name="*_txt_lv" type="text_lv"  indexed="true"  stored="true"/>
     <fieldType name="text_lv" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_lv.txt" />
         <filter class="solr.LatvianStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Dutch -->
     <dynamicField name="*_txt_nl" type="text_nl"  indexed="true"  stored="true"/>
     <fieldType name="text_nl" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_nl.txt" format="snowball" />
@@ -947,11 +947,11 @@
         <filter class="solr.SnowballPorterFilterFactory" language="Dutch"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Norwegian -->
     <dynamicField name="*_txt_no" type="text_no"  indexed="true"  stored="true"/>
     <fieldType name="text_no" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_no.txt" format="snowball" />
@@ -960,11 +960,11 @@
         <!-- singular/plural: <filter class="solr.NorwegianMinimalStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Portuguese -->
   <dynamicField name="*_txt_pt" type="text_pt"  indexed="true"  stored="true"/>
   <fieldType name="text_pt" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_pt.txt" format="snowball" />
@@ -974,22 +974,22 @@
         <!-- most aggressive: <filter class="solr.PortugueseStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Romanian -->
     <dynamicField name="*_txt_ro" type="text_ro"  indexed="true"  stored="true"/>
     <fieldType name="text_ro" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ro.txt" />
         <filter class="solr.SnowballPorterFilterFactory" language="Romanian"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Russian -->
     <dynamicField name="*_txt_ru" type="text_ru"  indexed="true"  stored="true"/>
     <fieldType name="text_ru" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ru.txt" format="snowball" />
@@ -997,11 +997,11 @@
         <!-- less aggressive: <filter class="solr.RussianLightStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Swedish -->
     <dynamicField name="*_txt_sv" type="text_sv"  indexed="true"  stored="true"/>
     <fieldType name="text_sv" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_sv.txt" format="snowball" />
@@ -1009,7 +1009,7 @@
         <!-- less aggressive: <filter class="solr.SwedishLightStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Thai -->
     <dynamicField name="*_txt_th" type="text_th"  indexed="true"  stored="true"/>
     <fieldType name="text_th" class="solr.TextField" positionIncrementGap="100">
@@ -1019,11 +1019,11 @@
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_th.txt" />
       </analyzer>
     </fieldType>
-    
+
     <!-- Turkish -->
     <dynamicField name="*_txt_tr" type="text_tr"  indexed="true"  stored="true"/>
     <fieldType name="text_tr" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.TurkishLowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="false" words="lang/stopwords_tr.txt" />
@@ -1032,8 +1032,8 @@
     </fieldType>
 
     <!-- Similarity is the scoring routine for each document vs. a query.
-       A custom Similarity or SimilarityFactory may be specified here, but 
-       the default is fine for most applications.  
+       A custom Similarity or SimilarityFactory may be specified here, but
+       the default is fine for most applications.
        For more info: http://wiki.apache.org/solr/SchemaXml#Similarity
     -->
     <!--

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -373,7 +373,6 @@
          (empty by default), down cases, and performs Unicode normalization.
          At query time only, it also applies synonyms.
 	  -->
-    <dynamicField name="*_txt_gen" type="text_general" indexed="true" stored="true" multiValued="true"/>
     <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100" multiValued="true">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>
@@ -456,13 +455,13 @@
 
     <!-- custom string-like sort field that ignores accents and case; using text because
          solr string field does not allow analyzers -->
-    <dynamicField name="*_s_en" type="string_en" indexed="true" stored="true" multiValued="false" />
-    <fieldType name="string_en" class="solr.TextField" sortMissingLast="true">
+    <dynamicField name="*_s_en" type="string_en" indexed="true" stored="true" />
+    <fieldType name="string_en" class="solr.TextField" sortMissingLast="true" multiValued="false">
        <analyzer type="index">
             <!-- treat entire field as a single token -->
             <tokenizer class="solr.KeywordTokenizerFactory"/>
             <!-- apply unicode normalization and case folding -->
-          <filter class="solr.ICUFoldingFilterFactory"/>
+            <filter class="solr.ICUFoldingFilterFactory"/>
        </analyzer>
        <!-- no query analyzer; only expected to be used for sorting, not
             querying or faceting -->

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -753,17 +753,15 @@
       <str name="defType">edismax</str>
       <!-- <str name="df">text</str> -->
 
-      <!-- name search pseudo field for members; for now, no unstemmed version or boosting -->
+      <!-- name search pseudo field for members -->
       <str name="name_qf">
         name_t^30
         sort_name_t^20
-        name_txt_gen^5
         name_ngram
       </str>
       <str name="name_pf">
         name_t^30
         sort_name_t^20
-        name_txt_gen^5
         name_ngram
       </str>
 

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -755,12 +755,16 @@
 
       <!-- name search pseudo field for members; for now, no unstemmed version or boosting -->
       <str name="name_qf">
-        name_t
-        sort_name_t
+        name_t^30
+        sort_name_t^20
+        name_txt_gen^5
+        name_ngram
       </str>
       <str name="name_pf">
-        name_t
-        sort_name_t
+        name_t^30
+        sort_name_t^20
+        name_txt_gen^5
+        name_ngram
       </str>
 
 


### PR DESCRIPTION
Changes for #363 #316 

- Adds unicode folding to general text solr field and adds a new ngram filter token field type and dynamic field. 
- Uses copy fields on person name and sort name to generate text and ngram versions
- Configures name search to use the new fields, but boosts primary name fields higher
- Updates alpha page label logic to compare case-insensitively to avoid discrepancies between the solr sorting and the display (note: we may want to revise the logic to ignore whitespace + punctuation at some point)
- Add directions to deploy notes about solr config change and indexing
- Unrelated to these features, while I was updating the alpha page labels I modified the solr query to get all page labels in a single query instead of getting them individually as we'd been doing previously. This should result in a performance improvement on the members list page.

Note: when I was working on this I had to unload and reload my solr core multiple times. I don't _think_ that should be necessary, and hope it's something to do with the tweaks I had to make as I refined the configuration. We might need to clear people from the index first (`manage.py -c person -i none`) before indexing.