### PR TITLE
update sorting behaviors for activities

### DIFF
--- a/mep/books/models.py
+++ b/mep/books/models.py
@@ -262,10 +262,10 @@ class Work(Notable, ModelIndexable):
         '''work creators with type author'''
         return self.creator_by_type('Author')
 
-    @property
     def author_list(self):
         '''semicolon separated list of author names'''
         return '; '.join([auth.name for auth in self.authors])
+    author_list.verbose_name = 'Authors'
 
     @property
     def sort_author_list(self):

--- a/mep/books/models.py
+++ b/mep/books/models.py
@@ -262,10 +262,15 @@ class Work(Notable, ModelIndexable):
         '''work creators with type author'''
         return self.creator_by_type('Author')
 
+    @property
     def author_list(self):
         '''semicolon separated list of author names'''
         return '; '.join([auth.name for auth in self.authors])
-    author_list.verbose_name = 'Authors'
+
+    @property
+    def sort_author_list(self):
+        '''semicolon separated list of author sort names'''
+        return '; '.join([auth.sort_name for auth in self.authors])
 
     @property
     def editors(self):

--- a/mep/books/tests/test_books_admin.py
+++ b/mep/books/tests/test_books_admin.py
@@ -153,7 +153,7 @@ class TestWorkAdmin(TestCase):
             assert item.title in item_data
             assert item.year in item_data
             # test some methods
-            assert item.author_list() in item_data
+            assert item.author_list in item_data
             assert item.admin_url() in item_data
             # test event counts from annotation
             for event_count in ('event_count', 'borrow_count',

--- a/mep/books/tests/test_books_admin.py
+++ b/mep/books/tests/test_books_admin.py
@@ -153,7 +153,7 @@ class TestWorkAdmin(TestCase):
             assert item.title in item_data
             assert item.year in item_data
             # test some methods
-            assert item.author_list in item_data
+            assert item.author_list() in item_data
             assert item.admin_url() in item_data
             # test event counts from annotation
             for event_count in ('event_count', 'borrow_count',

--- a/mep/books/tests/test_books_models.py
+++ b/mep/books/tests/test_books_models.py
@@ -256,6 +256,41 @@ class TestWork(TestCase):
         work.genres.add(genre2)
         assert work.genre_list() == '%s; %s' % (genre2.name, genre1.name)
 
+    def test_author_list(self):
+        # no authors
+        work = Work.objects.create(title='Anonymous')
+        assert work.author_list == ''
+        # one author
+        author_type = CreatorType.objects.get(name='Author')
+        author1 = Person.objects.create(name='Smith', slug='s')
+        Creator.objects.create(
+            creator_type=author_type, person=author1, work=work)
+        assert work.author_list == 'Smith'
+        # multiple authors
+        author2 = Person.objects.create(name='Jones', slug='j')
+        Creator.objects.create(
+            creator_type=author_type, person=author2, work=work)
+        assert work.author_list == 'Smith; Jones'
+
+    def test_sort_author_list(self):
+        # no authors
+        work = Work.objects.create(title='Anonymous')
+        assert work.author_list == ''
+        # one author
+        author_type = CreatorType.objects.get(name='Author')
+        author1 = Person.objects.create(name='Bob Smith',
+            sort_name='Smith, Bob', slug='s')
+        Creator.objects.create(
+            creator_type=author_type, person=author1, work=work)
+        assert work.sort_author_list == 'Smith, Bob'
+        # multiple authors
+        author2 = Person.objects.create(name='Bill Jones',
+            sort_name='Jones, Bill', slug='j')
+        Creator.objects.create(
+            creator_type=author_type, person=author2, work=work)
+        assert work.sort_author_list == 'Smith, Bob; Jones, Bill'
+
+
     def test_has_uri(self):
         work = Work(title='Topicless')
         assert not work.has_uri()

--- a/mep/books/tests/test_books_models.py
+++ b/mep/books/tests/test_books_models.py
@@ -113,7 +113,7 @@ class TestWork(TestCase):
 
         assert len(work.authors) == 1
         assert work.authors[0] == author1
-        assert work.author_list() == str(author1)
+        assert work.author_list == str(author1)
 
         # add second author
         Creator.objects.create(creator_type=author_type, person=author2,
@@ -121,7 +121,7 @@ class TestWork(TestCase):
         assert len(work.authors) == 2
         assert author1 in work.authors
         assert author2 in work.authors
-        assert work.author_list() == '%s; %s' % (author1, author2)
+        assert work.author_list == '%s; %s' % (author1, author2)
 
         assert len(work.editors) == 1
         assert work.editors[0] == editor

--- a/mep/books/tests/test_books_models.py
+++ b/mep/books/tests/test_books_models.py
@@ -113,7 +113,7 @@ class TestWork(TestCase):
 
         assert len(work.authors) == 1
         assert work.authors[0] == author1
-        assert work.author_list == str(author1)
+        assert work.author_list() == str(author1)
 
         # add second author
         Creator.objects.create(creator_type=author_type, person=author2,
@@ -121,7 +121,7 @@ class TestWork(TestCase):
         assert len(work.authors) == 2
         assert author1 in work.authors
         assert author2 in work.authors
-        assert work.author_list == '%s; %s' % (author1, author2)
+        assert work.author_list() == '%s; %s' % (author1, author2)
 
         assert len(work.editors) == 1
         assert work.editors[0] == editor
@@ -259,23 +259,23 @@ class TestWork(TestCase):
     def test_author_list(self):
         # no authors
         work = Work.objects.create(title='Anonymous')
-        assert work.author_list == ''
+        assert work.author_list() == ''
         # one author
         author_type = CreatorType.objects.get(name='Author')
         author1 = Person.objects.create(name='Smith', slug='s')
         Creator.objects.create(
             creator_type=author_type, person=author1, work=work)
-        assert work.author_list == 'Smith'
+        assert work.author_list() == 'Smith'
         # multiple authors
         author2 = Person.objects.create(name='Jones', slug='j')
         Creator.objects.create(
             creator_type=author_type, person=author2, work=work)
-        assert work.author_list == 'Smith; Jones'
+        assert work.author_list() == 'Smith; Jones'
 
     def test_sort_author_list(self):
         # no authors
         work = Work.objects.create(title='Anonymous')
-        assert work.author_list == ''
+        assert work.sort_author_list == ''
         # one author
         author_type = CreatorType.objects.get(name='Author')
         author1 = Person.objects.create(name='Bob Smith',

--- a/mep/people/templates/people/borrowing_activities.html
+++ b/mep/people/templates/people/borrowing_activities.html
@@ -76,7 +76,8 @@
             <td class="title{% if not event.work.title %} empty{% endif %}">
                 {{ event.work.title|default:'-' }}
             </td>
-            <td class="author{% if not event.work.author_list %} empty{% endif %}">
+            <td class="author{% if not event.work.author_list %} empty{% endif %}"
+                data-sort="{{ event.work.sort_author_list|default:'' }}">
                 {{ event.work.author_list|default:'-' }}
             </td>
             <td class="pubdate{% if not event.work.year %} empty{% endif %}">


### PR DESCRIPTION
this very small PR adds a convenience method to get all the author sort names for a `Work` for use in sorting in activity tables (`Work.sort_author_list`), and tests that method along with `Work.author_list` which wasn't tested yet. it also changes activity tables to use the new sort so that authors are sorted by sort name (i.e. last name first).

haven't found a simple way to sort dates with missing years last, but we could add a hack to make _completely_ missing dates default to `a` or any character, which would at least put them last.