### PR TITLE
Feature/linkable sections

### DIFF
--- a/mep/pages/management/commands/setup_site_pages.py
+++ b/mep/pages/management/commands/setup_site_pages.py
@@ -38,6 +38,7 @@ class Command(BaseCommand):
                 {'slug': 'cite', 'title': 'How to Cite'},
                 {'slug': 'credits', 'title': 'Credits'},
                 {'slug': 'technical', 'title': 'Technical'},
+                {'slug': 'faq', 'title': 'FAQ'}
             ]
         },
         {

--- a/mep/pages/models.py
+++ b/mep/pages/models.py
@@ -4,6 +4,8 @@ import bleach
 from django.db import models
 from django.http import Http404
 from django.template.defaultfilters import striptags, truncatechars_html
+from django.utils.functional import cached_property
+from django.utils.text import slugify
 from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel
 from wagtail.core import blocks
 from wagtail.core.fields import RichTextField, StreamField
@@ -51,6 +53,38 @@ class SVGImageBlock(blocks.StructBlock):
         label = 'SVG'
 
 
+class SlugStructValue(blocks.StructValue):
+    '''A :class:`~wagtail.core.blocks.StructValue` that enables generating a
+    slug from a title using django's `slugify`, for use as an anchor href.'''
+    # for more on usage of `StructValue`, see:
+    # https://docs.wagtail.io/en/v2.5/topics/streamfield.html#custom-value-class-for-structblock
+
+    @cached_property
+    def slug(self):
+        '''Slugify and return a StructBlock's title, if one is set.'''
+        # NOTE this implementation will compute this on every page load where
+        # a StructBlock that uses SlugStructValue is included.
+        # A different approach might take advantage of wagtail's hooks:
+        # https://docs.wagtail.io/en/v2.3/reference/hooks.html
+        title = self.get('title')
+        if title:
+            return slugify(title)
+
+
+class LinkableSectionBlock(blocks.StructBlock):
+    ''':class:`~wagtail.core.blocks.StructBlock` for a rich text block and an
+    associated `title` that will render as an <h2>. Creates an anchor (<a>)
+    so that the section can be directly linked to using a url fragment.'''
+    title = blocks.CharBlock()
+    body = blocks.RichTextBlock()
+
+    class Meta:
+        icon = 'form'
+        label = 'Linkable Section'
+        template = 'pages/snippets/linkable_section.html'
+        value_class = SlugStructValue # enables value.slug() in template
+
+
 class BodyContentBlock(blocks.StreamBlock):
     '''Common set of content blocks for content/analysis pages.'''
     paragraph = blocks.RichTextBlock(
@@ -63,6 +97,7 @@ class BodyContentBlock(blocks.StreamBlock):
         features=['ol', 'ul', 'bold', 'italic', 'link'],
         classname='footnotes'
     )
+    linkable_section = LinkableSectionBlock()
 
 
 class HomePage(Page):

--- a/mep/pages/models.py
+++ b/mep/pages/models.py
@@ -82,7 +82,7 @@ class LinkableSectionBlock(blocks.StructBlock):
         icon = 'form'
         label = 'Linkable Section'
         template = 'pages/snippets/linkable_section.html'
-        value_class = SlugStructValue # enables value.slug() in template
+        value_class = SlugStructValue       # enables value.slug() in template
 
 
 class BodyContentBlock(blocks.StreamBlock):

--- a/mep/pages/templates/pages/snippets/linkable_section.html
+++ b/mep/pages/templates/pages/snippets/linkable_section.html
@@ -1,0 +1,8 @@
+<span id="{{ value.slug }}"></span>
+<h2>
+    {{ value.title }}
+    <a class="headerlink"
+       href="#{{ value.slug }}"
+       title="Permalink to this section">¶</a>
+</h2>
+{{ value.bound_blocks.body.render }}

--- a/mep/pages/tests/test_pages_commands.py
+++ b/mep/pages/tests/test_pages_commands.py
@@ -45,7 +45,7 @@ class TestSetupSitePagesCommand(TestCase):
 
         assert EssayLandingPage.objects.count() == 1, 'should create analysis landing page'
 
-        assert ContentPage.objects.count() == 7, 'should create 7 content pages'
+        assert ContentPage.objects.count() == 8, 'should create 8 content pages'
 
         self.cmd.handle() # run again
 
@@ -58,5 +58,5 @@ class TestSetupSitePagesCommand(TestCase):
         assert EssayLandingPage.objects.count() == 1, \
             'running twice shouldn\'t create duplicate landing pages'
 
-        assert ContentPage.objects.count() == 7, 'running twice shouldn\'t \
+        assert ContentPage.objects.count() == 8, 'running twice shouldn\'t \
             create duplicate content pages'

--- a/mep/pages/tests/test_pages_models.py
+++ b/mep/pages/tests/test_pages_models.py
@@ -1,5 +1,7 @@
 import bleach
 from django.template.defaultfilters import striptags, truncatechars_html
+from django.test import SimpleTestCase
+from wagtail.core.blocks import CharBlock, StructBlock
 from wagtail.core.models import Page, Site
 from wagtail.tests.utils import WagtailPageTests
 from wagtail.tests.utils.form_data import (nested_form_data, rich_text,
@@ -7,8 +9,30 @@ from wagtail.tests.utils.form_data import (nested_form_data, rich_text,
 
 from mep.pages.models import (BasePage, ContentLandingPage, ContentPage,
                               EssayLandingPage, EssayPage, HomePage,
-                              LandingPage)
+                              LandingPage, LinkableSectionBlock,
+                              SlugStructValue)
 
+
+class TestLinkableSectionBlock(SimpleTestCase):
+
+    def test_render(self):
+        block = LinkableSectionBlock()
+        html = block.render(block.to_python({
+            'title': 'Joining the Lending Library',
+            'body': 'Info about lending library subscription plans'
+        }))
+        expected_html = '''
+            <span id="joining-the-lending-library"></span>
+            <h2>Joining the Lending Library
+            <a class="headerlink" href="#joining-the-lending-library"
+               title="Permalink to this section">¶</a>
+            </h2>
+            <div class="rich-text">
+                Info about lending library subscription plans
+            </div>
+        '''
+
+        self.assertHTMLEqual(html, expected_html)
 
 class TestHomePage(WagtailPageTests):
     fixtures = ['wagtail_pages']

--- a/srcmedia/scss/common/_article.scss
+++ b/srcmedia/scss/common/_article.scss
@@ -47,6 +47,13 @@ article.main {
         list-style: decimal inside;
     }
 
+    .linkable_section {
+
+        h2 {
+            margin-bottom: 1rem;
+        }
+    }
+
     .footnotes {
         border-top: 1px solid $light-grey;
         padding-top: 1rem;

--- a/srcmedia/scss/common/_link.scss
+++ b/srcmedia/scss/common/_link.scss
@@ -8,3 +8,22 @@ main a {
         border-bottom: 2px solid $dark-green;
     }
 }
+
+// '¶' links to linkable sections in body text
+.headerlink {
+    color: $green;
+    border: none;
+    opacity: 0;
+    font-size: 1rem;
+    transition: opacity 0.2s ease-in-out;
+    position: relative;
+    top: -0.2rem;
+
+    &:hover, &:focus {
+        border: none;
+    }
+}
+
+h2:hover > .headerlink {
+    opacity: 1;
+}


### PR DESCRIPTION
this adds a new "Linkable Section" block in wagtail. the title you specify for that block will get slugified and used to create an anchor link that will jump to that point on the page. you can see and click the link by hovering over the generated heading, just like with django's docs.

i implemented the slugification as part of a [`StructValue` class](https://docs.wagtail.io/en/v2.5/topics/streamfield.html#custom-value-class-for-structblock) that allows requesting `value.slug` in the template if the `LinkableSectionBlock` has a defined `title`. from what I can tell, it's being computed every time the template is rendered. there is probably a better way involving overriding `clean()` for `LinkableSectionBlock` and caching the slug, but I don't know how to store arbitrary data along with a block, because afaict they are not persisted except as parts of pages.

this PR also adds a line to generate the new "FAQ" page, which will host most of these linkable sections, automatically as part of `setup_site_pages`.