### PR TITLE
Unicode folding for member search and name sort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ install:
 - npm ci # installs from package-lock.json
 before_script:
 - SOLR_VERSION=$SOLR_VERSION SOLR_CORE=$SOLR_CORE bash ci/config_solr.sh
-#- cp -r solr_conf downloads/solr-${SOLR_VERSION}/server/solr/configsets/sandco  # copy in local configset
 - npm run build:prod # compile static assets
 - mysql -u root -e "create database travismep"; # setup a test db for pa11y
 - mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 - npm ci # installs from package-lock.json
 before_script:
 - SOLR_VERSION=$SOLR_VERSION SOLR_CORE=$SOLR_CORE bash ci/config_solr.sh
-- cp -r solr_conf downloads/solr-${SOLR_VERSION}/server/solr/configsets/sandco  # copy in local configset
+#- cp -r solr_conf downloads/solr-${SOLR_VERSION}/server/solr/configsets/sandco  # copy in local configset
 - npm run build:prod # compile static assets
 - mysql -u root -e "create database travismep"; # setup a test db for pa11y
 - mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql

--- a/DEPLOYNOTES.rst
+++ b/DEPLOYNOTES.rst
@@ -8,8 +8,9 @@ Deploy and Upgrade notes
 
 Partial name search on the members list page requires that the Solr
 configuration be updated and members reindexed. Copy all files under
-`solr_conf/conf/` to your configured Solr configset. Then update the
-schema and reindex::
+`solr_conf/conf/` to your configured Solr configset and restart Solr
+to ensure the managed schema is loaded. Then update the schema and
+reindex::
 
   python manage.py solr_schema
   python manage.py index -i person

--- a/ci/config_solr.sh
+++ b/ci/config_solr.sh
@@ -18,7 +18,8 @@ fi
 tar xzf $file
 
 # copy in local configset in before starting
-cp -r ../solr_conf solr-${SOLR_VERSION}/server/solr/configsets/sandco
+mkdir solr-${SOLR_VERSION}/server/solr/configsets/sandco
+cp -r ../solr_conf/* solr-${SOLR_VERSION}/server/solr/configsets/sandco/
 
 # Start the solr instance with all default settings
 echo "Starting solr..."

--- a/ci/config_solr.sh
+++ b/ci/config_solr.sh
@@ -17,6 +17,9 @@ fi
 # Untar
 tar xzf $file
 
+# copy in local configset in before starting
+cp -r ../solr_conf solr-${SOLR_VERSION}/server/solr/configsets/sandco
+
 # Start the solr instance with all default settings
 echo "Starting solr..."
 bin="solr-${version}/bin/solr"

--- a/mep/common/tests.py
+++ b/mep/common/tests.py
@@ -291,6 +291,14 @@ def test_alpha_pagelabels():
     paginator = Paginator([], per_page=20)
     assert not alpha_pagelabels(paginator, [], lambda x: getattr(x, 'title'))
 
+    # case-insensitive
+    titles = ['Core', 'd\'Aricourt', 'D\'Assay', 'Estaing']
+    items = [Item(t) for t in titles]
+    paginator = Paginator(items, per_page=2)
+    labels = alpha_pagelabels(paginator, items, lambda x: getattr(x, 'title'))
+    assert labels[1].endswith("d'Ar")
+    assert labels[2].startswith("D'As")
+
 
 class TestLabeledPagesMixin(TestCase):
 

--- a/mep/common/utils.py
+++ b/mep/common/utils.py
@@ -91,7 +91,11 @@ def alpha_pagelabels(paginator, objects, attr_meth):
             abbr += char   # or abbr = label[:j]
             # if abbreviation is different from neighboring labels
             # at the current length, then use it
-            if abbr not in (next_label[:j], prev_label[:j]):
+            # - compare case-insensitively
+            # NOTE: should possibly ignore trailing punctuation here...
+            # possible to get "Gray" / "Gray,"
+            if abbr.lower() not in (next_label[:j].lower(),
+                                    prev_label[:j].lower()):
                 break
             # if we don't break before the loop finishes, use
             # the whole label

--- a/mep/people/models.py
+++ b/mep/people/models.py
@@ -613,8 +613,8 @@ class Person(Notable, DateRange, ModelIndexable):
             'slug_s': self.slug,
             # text version of sort name for search and display
             'sort_name_t': self.sort_name,
-            # string version of sort name for sort/facet
-            'sort_name_sort_s': self.sort_name,
+            # sort version of sort name
+            'sort_name_isort': self.sort_name,
             'birth_year_i': self.birth_year,
             'death_year_i': self.death_year,
             'has_card_b': self.has_card(),

--- a/mep/people/tests/test_views.py
+++ b/mep/people/tests/test_views.py
@@ -729,6 +729,23 @@ class TestMembersListView(TestCase):
 
         # TODO: not sure how to test pagination/multiple pages
 
+        # test partial match
+        response = self.client.get(self.members_url, {'query': "heming"})
+        self.assertContains(response, "Hemingway, Ernest")
+
+        # test accent folding
+        rene_account = Account.objects.create()
+        rene = Person.objects.create(sort_name='Chambrillac, René', slug='ren')
+        rene_account.persons.add(rene)
+        Person.index_items([rene])
+        time.sleep(1)
+        # with accent
+        response = self.client.get(self.members_url, {'query': "rené"})
+        self.assertContains(response, rene.sort_name)
+        # without accent
+        response = self.client.get(self.members_url, {'query': "rene"})
+        self.assertContains(response, rene.sort_name)
+
     def test_get_page_labels(self):
         view = MembersList()
         # patch out get_form

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -121,7 +121,7 @@ class MembersList(LabeledPagesMixin, ListView, FormMixin,
     # map form sort to solr sort field
     solr_sort = {
         'relevance': '-score',
-        'name': 'sort_name_sort_s'
+        'name': 'sort_name_isort'
     }
 
     def get_queryset(self):

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -1060,8 +1060,9 @@
 
     <!-- custom string-like sort field that ignores accents; using text because
          solr string field does not allow analyzers -->
-    <dynamicField name="*_isort" type="string_isort" indexed="true" stored="true" />
-    <fieldType name="string_isort" class="solr.TextField" sortMissingLast="true">
+    <dynamicField name="*_isort" type="string_isort" indexed="true" stored="true" multiValued="false"/>
+    <field name="sort_name_isort" type="string_isort" indexed="true" stored="true" multiValued="false" />
+    <fieldType name="string_isort" class="solr.TextField" sortMissingLast="true" multiValued="false">
       <analyzer>
             <!-- treat entire field as a single token -->
             <tokenizer class="solr.KeywordTokenizerFactory"/>

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -1058,4 +1058,16 @@
       </analyzer>
     </fieldType>
 
+    <!-- custom string-like sort field that ignores accents; using text because
+         solr string field does not allow analyzers -->
+    <dynamicField name="*_isort" type="string_isort" indexed="true" stored="true" />
+    <fieldType name="string_isort" class="solr.TextField" sortMissingLast="true">
+      <analyzer>
+            <!-- treat entire field as a single token -->
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <!-- apply unicode normalization and case folding -->
+            <filter class="solr.ICUFoldingFilterFactory"/>
+       </analyzer>
+    </fieldType>
+
 </schema>

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -387,7 +387,7 @@
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-         <filter class="solr.ICUFoldingFilterFactory"/>
+        <filter class="solr.ICUFoldingFilterFactory"/>
       </analyzer>
     </fieldType>
 
@@ -1061,7 +1061,6 @@
     <!-- custom string-like sort field that ignores accents; using text because
          solr string field does not allow analyzers -->
     <dynamicField name="*_isort" type="string_isort" indexed="true" stored="true" multiValued="false"/>
-    <field name="sort_name_isort" type="string_isort" indexed="true" stored="true" multiValued="false" />
     <fieldType name="string_isort" class="solr.TextField" sortMissingLast="true" multiValued="false">
       <analyzer>
             <!-- treat entire field as a single token -->

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -381,13 +381,13 @@
         <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
         <filter class="solr.FlattenGraphFilterFactory"/>
         -->
-        <filter class="solr.LowerCaseFilterFactory"/>
+         <filter class="solr.ICUFoldingFilterFactory"/>
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
+         <filter class="solr.ICUFoldingFilterFactory"/>
       </analyzer>
     </fieldType>
 


### PR DESCRIPTION
- add icu folding to general text field in solr config
- define a new field type and dynamic field for case/accent-insensitive sorting
- revise the build to make sure configset is copied in properly and before solr starts (needs a little more cleanup, feedback welcome)
- adjust alpha page label logic to be case-insensitive
