### PR TITLE
Chore/info links

### DIFF
--- a/mep/people/forms.py
+++ b/mep/people/forms.py
@@ -66,8 +66,7 @@ class MemberSearchForm(FacetForm):
             'class': 'choice facet',
             'aria-describedby': 'gender_tip'
         }),
-        help_text='Learn more about gender and its representation in the Project \
-        in the Analysis section.')
+        help_text='Click to learn more about gender representation in the Project.')
     membership_dates = RangeField(label='Membership Dates', required=False,
                                   widget=RangeWidget(attrs={'size': 4}))
     birth_year = RangeField(label='Birth Year', required=False,

--- a/mep/people/templates/people/member_list.html
+++ b/mep/people/templates/people/member_list.html
@@ -46,8 +46,9 @@
                                 {{ form.birth_year }}
                             </fieldset>
                             {% render_field form.gender %}
-                            <span id="{{ form.gender.field.widget.attrs|dict_item:'aria-describedby' }}" role="tooltip"
-                                aria-label="{{ form.gender.help_text }}" tabindex=0/>
+                            <a class="info-link" href="/about/faq#why-assign-gender"
+                                title="{{ form.gender.help_text }}" tabindex="0"
+                                id="{{ form.gender.field.widget.attrs|dict_item:'aria-describedby' }}"></a>
                         </div>
                         <div class="column">
                             <div class="expander" role="button" aria-controls="id_nationality" tabindex="0" aria-expanded="false">{{ form.nationality.label }}</div>

--- a/mep/people/templates/people/membership_activities.html
+++ b/mep/people/templates/people/membership_activities.html
@@ -81,6 +81,12 @@
             <td class="activity">{{ event.event_type }}</td>
             <td class="plan{% if not event.subscription.category %} empty{% endif %}">
                 {{ event.subscription.category|default:'-' }}
+                {# render info link here so it can be shown on mobile too #}
+                {% if forloop.first %}
+                <a class="info-link" href="/about/faq#joining-the-library"
+                    title="{{ plan_tooltip }}" tabindex="0"
+                    id="plan-tip-2"></a>
+                {% endif %}
             </td>
             <td class="duration{% if not event.subscription.duration %} empty{% endif %}"
                 data-sort="{{ event.subscription.duration|default:0 }}">

--- a/mep/people/templates/people/membership_activities.html
+++ b/mep/people/templates/people/membership_activities.html
@@ -65,10 +65,10 @@
         <thead>
             <tr>
                 <th>Activity</th>
-                <th aria-describedby="plan-tip" data-sort-method="none">Plan
-                    <span id="plan-tip" role="tooltip" class="question"
-                        aria-label="{{ plan_tooltip }}" tabindex=0
-                        onclick="event.preventDefault()"/>
+                <th data-sort-method="none">Plan
+                    <a class="info-link" href="/about/faq#joining-the-library"
+                        title="{{ plan_tooltip }}" tabindex="0"
+                        id="plan-tip"></a>
                 </th>
                 <th data-sort-method="number">Duration</th>
                 <th data-sort-default>Start Date</th>

--- a/mep/people/tests/test_views.py
+++ b/mep/people/tests/test_views.py
@@ -611,8 +611,9 @@ class TestMembersListView(TestCase):
         self.assertContains(response, '<span class="count">1</span>', count=4)
         # the filter should have a card image (counted later with other result
         # card icon) and it should have a tooltip
-        # total 2 tooltips on page since gender facet will also have one
-        self.assertContains(response, 'role="tooltip"', count=2)
+        self.assertContains(response, 'role="tooltip"', count=1)
+        # gender facet has an info link
+        self.assertContains(response, 'class="info-link"', count=1)
         # the tooltip should have an aria-label set
         self.assertContains(response, 'aria-label="Limit to members', count=1)
         # the input should be aria-describedby the tooltip

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -343,7 +343,7 @@ class MembershipActivities(ListView, RdfViewMixin):
     model = Event
     template_name = 'people/membership_activities.html'
     # tooltip text shown to explain the 'plan' column in the table
-    PLAN_TOOLTIP = 'More information coming soon.'
+    PLAN_TOOLTIP = 'Click to learn more about library subscription plans.'
 
     def get_queryset(self):
         # filter to requested person, then get membership activities

--- a/srcmedia/scss/common/_link.scss
+++ b/srcmedia/scss/common/_link.scss
@@ -1,3 +1,4 @@
+// normal links with green underline
 main a {
     color: $black;
     text-decoration: none;
@@ -26,4 +27,20 @@ main a {
 
 h2:hover > .headerlink {
     opacity: 1;
+}
+
+// info links using 'link' icon
+.info-link {
+    border: none;
+    width: 0.8rem;
+    min-height: 0.8rem;
+    background-image: url('/static/img/icons/link-circle.svg');
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 100%;
+    display: inline-block;
+
+    &:hover, &:focus {
+        border: none;
+    }
 }

--- a/srcmedia/scss/members/_forms.scss
+++ b/srcmedia/scss/members/_forms.scss
@@ -93,47 +93,16 @@
         }
     }
 
-    // gender facet tooltip
-    // tooltip text flips to below icon on tablet and back to above on desktop
-    // because it can't exceed the bounds of its parent container (column)
+    // gender facet info link
     #gender_tip {
         height: fit-content;
         position: absolute;
-        top: 3rem;
-        right: 0.5rem;
+        top: 3.2rem;
+        left: 4rem;
 
         @media (min-width: $breakpoint-s) {
-            top: 4.25rem;
-            right: 1rem;
-        }
-
-        &::before {
-            bottom: 0.5rem;
-            transform-origin: bottom center;
-
-            @media (min-width: $breakpoint-s) {
-                transform: rotate(180deg);
-            }
-
-            @media (min-width: $breakpoint-m) {
-                transform: none;
-            }
-        }
-
-        &::after {
-            right: 0;
-            bottom: 1.25rem;
-            min-width: 9rem;
-
-            @media (min-width: $breakpoint-s) {
-                bottom: -4.25rem;
-                right: -0.5rem;
-            }
-
-            @media (min-width: $breakpoint-m) {
-                bottom: 1.25rem;
-                min-width: 11rem; // larger on desktop
-            }
+            top: 4.35rem;
+            left: 4.25rem;
         }
     }
 

--- a/srcmedia/scss/members/_membership.scss
+++ b/srcmedia/scss/members/_membership.scss
@@ -63,7 +63,7 @@
             }
 
             &::before {
-                content: 'Category';
+                content: 'Plan';
             }
         }
 
@@ -80,12 +80,16 @@
 
 // "plan" tooltip
 #plan-tip {
-    font-weight: normal;
     vertical-align: middle;
-    min-height: 1.35rem;
-    position: relative;
+}
 
-    &::after {
-        width: 6rem;
+// "plan" tooltip for mobile
+#plan-tip-2 {
+    position: absolute;
+    top: -.7rem;
+    right: calc(50% - 1.75rem);
+
+    @media (min-width: $breakpoint-s) {
+        display: none;
     }
 }


### PR DESCRIPTION
addresses #456 

changes the tooltips next to the gender facet and the "plan" column on borrowing activities into the new info links. they're pointed to arbitrary locations currently and will need to be updated once the relevant sections are created on the FAQ page.