### PR TITLE
handle missing library address in map

### DIFF
--- a/DEPLOYNOTES.rst
+++ b/DEPLOYNOTES.rst
@@ -3,6 +3,13 @@
 Deploy and Upgrade notes
 ========================
 
+0.25
+----
+
+* The name of the canonical `Location` representing the library should be
+  changed to "Shakespeare and Company" (no &), if it is not already. This change
+  has been reflected in an earlier migration.
+
 0.24
 ----
 

--- a/mep/people/migrations/0014_library_location.py
+++ b/mep/people/migrations/0014_library_location.py
@@ -9,7 +9,7 @@ def add_library_address(apps, schema_editor):
     # adds the known location for the Shakespeare and Company lending library
     # as a Location, so it can be used to draw the library's pin on maps
     Location = apps.get_model('people', 'Location')
-    Location.objects.get_or_create(name='Shakespeare & Company', city='Paris',
+    Location.objects.get_or_create(name='Shakespeare and Company', city='Paris',
                                    street_address='12 rue de l’Odéon',
                                    latitude=48.85089, longitude=2.338502,
                                    notes='location from 1921-1941')

--- a/mep/people/tests/test_views.py
+++ b/mep/people/tests/test_views.py
@@ -1047,11 +1047,18 @@ class TestMemberDetailView(TestCase):
         assert 'mapbox_basemap' in response.context
         assert 'paris_overlay' in response.context
         # address of the library itself should be in context
-        assert response.context['library_address']['name'] == 'Shakespeare & Company'
+        assert response.context['library_address']['name'] == 'Shakespeare and Company'
         # Gay's address info should be in context
         assert response.context['addresses'][0]['street_address'] == '3 Rue Garancière'
         assert response.context['addresses'][0]['latitude'] == '48.85101'
         assert response.context['addresses'][0]['longitude'] == '2.33590'
+        # if we don't have the library's address, page should still render
+        library = Location.objects.get(name='Shakespeare and Company')
+        library.delete()
+        response = self.client.get(url)
+        assert response.status_code == 200
+        # library address is rendered as "null"
+        self.assertContains(response, "libraryAddress = null")
 
     def test_get_non_member(self):
         aeschylus = Person.objects.get(name='Aeschylus', slug='aeschylus')

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -292,6 +292,8 @@ class MemberDetail(DetailView, RdfViewMixin):
             .filter(location__latitude__isnull=False) \
             .filter(location__longitude__isnull=False)
 
+        # NOTE probably refactor this into a method on Location for feeding
+        # to leaflet; also use below
         context['addresses'] = [
             {
                 # these fields are taken from Location unchanged

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -308,14 +308,18 @@ class MemberDetail(DetailView, RdfViewMixin):
 
         # address of the lending library itself; automatically available from
         # migration mep/people/migrations/0014_library_location.py
-        library = Location.objects.get(name='Shakespeare & Company')
-        context['library_address'] = {
-            'name': library.name,
-            'street_address': library.street_address,
-            'city': library.city,
-            'latitude': str(library.latitude),
-            'longitude': str(library.longitude),
-        }
+        try:
+            library = Location.objects.get(name='Shakespeare and Company')
+            context['library_address'] = {
+                'name': library.name,
+                'street_address': library.street_address,
+                'city': library.city,
+                'latitude': str(library.latitude),
+                'longitude': str(library.longitude),
+            }
+        except Location.DoesNotExist:
+            # if we can't find library's address send 'null' & don't render it
+            context['library_address'] = None
 
         # config settings used to render the map; set in local_settings.py
         context.update({

--- a/srcmedia/ts/members-map.ts
+++ b/srcmedia/ts/members-map.ts
@@ -13,7 +13,7 @@ type Address = {
     end_date?: string,
 }
 declare const addressData: Array<Address>
-declare const libraryAddress: Address
+declare const libraryAddress: Address|null
 
 // defined in local_settings.py and passed in the django view/template
 declare const mapboxToken: string
@@ -51,21 +51,27 @@ parisTiles.addTo(addressMap)
 /*
  * bookstore icon + marker on map
  */
-const bookstoreIcon = icon({
-    iconUrl: '/static/img/icons/bookstore-pin.svg',
-    iconSize: [46, 62],
-    iconAnchor: [23, 62],
-    popupAnchor: [0, -60]
-})
 
-const bookstoreMarker = marker([libraryAddress.latitude, libraryAddress.longitude], {
-    icon: bookstoreIcon,
-    zIndexOffset: 1, // on top of address markers
-})
+let bookstoreMarker
 
-bookstoreMarker.bindPopup(popupText(libraryAddress))
+if (libraryAddress) { // only add if data is available
 
-bookstoreMarker.addTo(addressMap)
+    const bookstoreIcon = icon({
+        iconUrl: '/static/img/icons/bookstore-pin.svg',
+        iconSize: [46, 62],
+        iconAnchor: [23, 62],
+        popupAnchor: [0, -60]
+    })
+    
+    bookstoreMarker = marker([libraryAddress.latitude, libraryAddress.longitude], {
+        icon: bookstoreIcon,
+        zIndexOffset: 1, // on top of address markers
+    })
+    
+    bookstoreMarker.bindPopup(popupText(libraryAddress))
+    
+    bookstoreMarker.addTo(addressMap)
+}
 
 /*
  * address icons + markers on map
@@ -117,7 +123,9 @@ addressMarkers
  * set up initial zoom/view
  */
 // zoom to fit all markers
-const allMarkers = featureGroup([bookstoreMarker, ...addressMarkers])
+const allMarkers = featureGroup([...addressMarkers])
+if (bookstoreMarker) allMarkers.addLayer(bookstoreMarker)
+
 addressMap.fitBounds(allMarkers.getBounds().pad(0.1))
 
 // open the first marker: needs a delay otherwise the text inside will be


### PR DESCRIPTION
refs #512 

I also updated the migration that initially creates the library's address to use "and" instead of "&".