### PR TITLE
Issue/volume list for work bibliography page

### DIFF
--- a/mep/accounts/management/commands/export_events.py
+++ b/mep/accounts/management/commands/export_events.py
@@ -40,8 +40,6 @@ class Command(BaseExport):
         # related book/item
         'item title', 'item work uri', 'item volume',
         'item notes',
-        # generic
-        'notes',
         # footnote/citation
         'source citation', 'source manifest', 'source image'
     ]
@@ -105,8 +103,6 @@ class Command(BaseExport):
         item_info = self.item_info(obj)
         if item_info:
             data['item'] = item_info
-        if obj.notes:
-            data['notes'] = obj.notes
         if footnote:
             data['source'] = self.source_info(footnote)
         return data
@@ -154,9 +150,7 @@ class Command(BaseExport):
                 ('title', event.work.title),
             ])
             if event.edition:
-                # NOTE: using string representation for now,
-                # will revisit to refine later
-                item_info['volume'] = str(event.edition)
+                item_info['volume'] = event.edition.display_text()
             if event.work.uri:
                 item_info['work uri'] = event.work.uri
             if event.work.public_notes:

--- a/mep/accounts/tests/test_accounts_commands.py
+++ b/mep/accounts/tests/test_accounts_commands.py
@@ -489,7 +489,7 @@ class TestExportEvents(TestCase):
         # event with known edition
         event = Event.objects.filter(edition__isnull=False).first()
         info = self.cmd.item_info(event)
-        assert info['volume'] == str(event.edition)
+        assert info['volume'] == event.edition.display_text()
 
         # no work, no item data
         event = Event.objects.filter(work__isnull=True).first()

--- a/mep/books/models.py
+++ b/mep/books/models.py
@@ -522,15 +522,13 @@ class Edition(Notable):
             parts.append('Vol. %s' % self.volume)
         if self.number:
             parts.append('no. %s' % self.number)
-        if self.season:
-            parts.append(self.season)
+        if self.season or self.date:
+            season_year = '%s %s' % (
+                self.season,
+                self.date.year if self.date else '')
+            parts.append(season_year.strip())
 
         citation = ', '.join(parts)
-
-        # date is partial but we only want year;
-        # assuming year is known if set
-        if self.date:
-            citation = '%s %s' % (citation, self.date.year)
 
         if self.title:
             return format_html('{} <br/><em>{}</em>',

--- a/mep/books/models.py
+++ b/mep/books/models.py
@@ -5,7 +5,7 @@ import requests
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.urls import reverse
-from django.utils.html import format_html
+from django.utils.html import format_html, strip_tags
 from parasolr.django.indexing import ModelIndexable
 
 from mep.accounts.partial_date import (DatePrecisionField, PartialDate,
@@ -533,9 +533,13 @@ class Edition(Notable):
             citation = '%s %s' % (citation, self.date.year)
 
         if self.title:
-            return format_html('{}<br/><em>{}</em>',
+            return format_html('{} <br/><em>{}</em>',
                                citation, self.title)
         return citation
+
+    def display_text(self):
+        '''text-only version of volume/issue citation'''
+        return strip_tags(self.display_html())
 
 
 class CreatorType(Named, Notable):

--- a/mep/books/models.py
+++ b/mep/books/models.py
@@ -5,6 +5,7 @@ import requests
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.urls import reverse
+from django.utils.html import format_html
 from parasolr.django.indexing import ModelIndexable
 
 from mep.accounts.partial_date import (DatePrecisionField, PartialDate,
@@ -512,6 +513,29 @@ class Edition(Notable):
             parts.append(self.season)
         # include edition?
         return ' '.join(parts)
+
+    def display_html(self):
+        '''Render volume/issue citation with formatting, suitable
+        for inclusion on a webpage.'''
+        parts = []
+        if self.volume:
+            parts.append('Vol. %s' % self.volume)
+        if self.number:
+            parts.append('no. %s' % self.number)
+        if self.season:
+            parts.append(self.season)
+
+        citation = ', '.join(parts)
+
+        # date is partial but we only want year;
+        # assuming year is known if set
+        if self.date:
+            citation = '%s %s' % (citation, self.date.year)
+
+        if self.title:
+            return format_html('{}<br/><em>{}</em>',
+                               citation, self.title)
+        return citation
 
 
 class CreatorType(Named, Notable):

--- a/mep/books/templates/books/work_detail.html
+++ b/mep/books/templates/books/work_detail.html
@@ -18,7 +18,7 @@
         <a href="#">events</a>
     </li>
 </nav>
-<section class="details">
+<section class="details" aria-label="bibliography">
     {% include 'books/snippets/work_result.html' %}
 
 {% if work.edition_set.exists %}

--- a/mep/books/templates/books/work_detail.html
+++ b/mep/books/templates/books/work_detail.html
@@ -20,21 +20,19 @@
 </nav>
 <section class="details">
     {% include 'books/snippets/work_result.html' %}
-</section>
+
 {% if work.edition_set.exists %}
-<section class="volumes-issues">
+<div class="volumes-issues">
     <h2>Volume/Issue</h2>
     <ul>
     {% for edition in work.edition_set.all %}
     <li>
-        {% if edition.volume %}Vol. {{ edition.volume }}{% endif %}
-        {% if edition.number %}, no. {{ edition.number }}{% endif %}
-        {% if edition.season %}, {{ edition.season }}{% endif %}
-        {% if edition.year %} {{ edition.year }}{% endif %}
-        {% if edition.title %}<em>{{ edition.title }}</em>{% endif %}
+        {{ edition.display_html }}
     </li>
     {% endfor %}
     </ul>
+</div>
+
 </section>
 {% endif %}
 

--- a/mep/books/tests/test_books_models.py
+++ b/mep/books/tests/test_books_models.py
@@ -404,7 +404,7 @@ class TestEdition(TestCase):
         # edition date takes precedence
         edition.partial_date = '1920'
         assert str(edition) == '%s (%s)' % (edition.title, edition.partial_date)
-        
+
         # includes volume, number, season when present
         edition.volume = 2
         assert str(edition) == '%s (%s) vol. 2' % (edition.title,
@@ -430,6 +430,28 @@ class TestEdition(TestCase):
         # saved repr
         edition.save()
         assert repr(edition) == '<Edition pk:%d %s>' % (edition.pk, edition)
+
+    def test_display_html(self):
+        work = Work.objects.create(title='transition')
+        # volume only
+        edition = Edition(work=work, volume=3)
+        assert edition.display_html() == 'Vol. 3'
+        # volume + number
+        edition.number = '19a'
+        assert edition.display_html() == 'Vol. 3, no. 19a'
+        # volume + number + season
+        edition.season = 'Winter'
+        assert edition.display_html() == 'Vol. 3, no. 19a, Winter'
+        # volume + number + season + year
+        edition.date = datetime.date(1931, 1, 1)
+        assert edition.display_html() == 'Vol. 3, no. 19a, Winter 1931'
+        # number + season + date, no volume
+        edition.volume = None
+        assert edition.display_html() == 'no. 19a, Winter 1931'
+        # with title
+        edition.title = 'Subsection'
+        assert edition.display_html() == \
+            'no. 19a, Winter 1931<br/><em>Subsection</em>'
 
 
 class TestEditionCreator(TestCase):

--- a/mep/books/tests/test_books_models.py
+++ b/mep/books/tests/test_books_models.py
@@ -453,6 +453,11 @@ class TestEdition(TestCase):
         assert edition.display_html() == \
             'no. 19a, Winter 1931 <br/><em>Subsection</em>'
 
+        # title and year but no season
+        edition.season = ''
+        assert edition.display_html() == \
+            'no. 19a, 1931 <br/><em>Subsection</em>'
+
     def test_display_text(self):
         work = Work.objects.create(title='transition')
         # volume only
@@ -460,7 +465,7 @@ class TestEdition(TestCase):
                           date=datetime.date(1931, 1, 1),
                           title='subtitle')
         assert edition.display_text() == \
-            'Vol. 3 1931 subtitle'
+            'Vol. 3, 1931 subtitle'
 
 
 class TestEditionCreator(TestCase):

--- a/mep/books/tests/test_books_models.py
+++ b/mep/books/tests/test_books_models.py
@@ -451,7 +451,16 @@ class TestEdition(TestCase):
         # with title
         edition.title = 'Subsection'
         assert edition.display_html() == \
-            'no. 19a, Winter 1931<br/><em>Subsection</em>'
+            'no. 19a, Winter 1931 <br/><em>Subsection</em>'
+
+    def test_display_text(self):
+        work = Work.objects.create(title='transition')
+        # volume only
+        edition = Edition(work=work, volume=3,
+                          date=datetime.date(1931, 1, 1),
+                          title='subtitle')
+        assert edition.display_text() == \
+            'Vol. 3 1931 subtitle'
 
 
 class TestEditionCreator(TestCase):

--- a/srcmedia/scss/books/_details.scss
+++ b/srcmedia/scss/books/_details.scss
@@ -64,3 +64,9 @@ dl.book {
     //     margin-top: 1rem;
     // }
 }
+
+.volumes-issues {
+    em {
+        font-style: italic;
+    }
+}


### PR DESCRIPTION
- new method to Edition to generate formatted citation for display on work detail page
- new plain text method with the same data
- use the formatted version for the work bibliography page
- use the plain text version for the event data export
- also removes the event notes field from event data export

ref #520 #540 

Particularly interested in: 
- any suggestions for better names for the methods?
- any suggestions for changes to the html formatting used by the display method?