### PR TITLE
book export manage command

### DIFF
--- a/mep/accounts/management/commands/export_events.py
+++ b/mep/accounts/management/commands/export_events.py
@@ -38,7 +38,7 @@ class Command(BaseExport):
         # purchase specific
         'purchase price',
         # related book/item
-        'item title', 'item work uri', 'item volume',
+        'item uri', 'item title', 'item work uri', 'item volume',
         'item notes',
         # footnote/citation
         'source citation', 'source manifest', 'source image'
@@ -147,6 +147,7 @@ class Command(BaseExport):
         '''associated work details for an event'''
         if event.work:
             item_info = OrderedDict([
+                ('uri', absolutize_url(event.work.get_absolute_url())),
                 ('title', event.work.title),
             ])
             if event.edition:

--- a/mep/accounts/tests/test_accounts_commands.py
+++ b/mep/accounts/tests/test_accounts_commands.py
@@ -474,6 +474,7 @@ class TestExportEvents(TestCase):
             .exclude(work__uri='').exclude(work__public_notes='').first()
         info = self.cmd.item_info(event)
         assert info['title'] == event.work.title
+        assert info['uri'] == absolutize_url(event.work.get_absolute_url())
         assert info['work uri'] == event.work.uri
         assert info['notes'] == event.work.public_notes
         assert 'volume' not in info

--- a/mep/books/fixtures/sample_works.json
+++ b/mep/books/fixtures/sample_works.json
@@ -9,7 +9,8 @@
 			"year": 1912,
 			"slug": "exit-eliza",
 			"work_format": 1,
-			"uri": "http://www.worldcat.org/oclc/2777112"
+			"uri": "http://www.worldcat.org/oclc/2777112",
+			"updated_at": "2020-03-27T13:26:15Z"
 		}
 	},
 	{
@@ -22,7 +23,8 @@
 			"year": null,
 			"uri": "",
 			"slug": "grimm-fairy-tales",
-			"work_format": 1
+			"work_format": 1,
+			"updated_at": "2020-03-27T13:26:15Z"
 		}
 	},
 	{
@@ -35,7 +37,8 @@
 			"year": null,
 			"work_format": 1,
 			"uri": "http://worldcat.org/entity/work/id/4918580916",
-			"slug": "kreutzer-sonata"
+			"slug": "kreutzer-sonata",
+			"updated_at": "2020-03-27T13:26:15Z"
 		}
 	},
 	{
@@ -49,7 +52,8 @@
 			"uri": "",
 			"slug": "chronicle-life",
 			"work_format": 1,
-			"public_notes": "Here are some public notes."
+			"public_notes": "Here are some public notes.",
+			"updated_at": "2020-03-27T13:26:15Z"
 		}
 	},
 	{
@@ -62,7 +66,8 @@
 			"year": null,
 			"uri": "",
 			"slug": "murder-blue-train",
-			"work_format": 1
+			"work_format": 1,
+			"updated_at": "2020-03-27T13:26:15Z"
 		}
 	},
 	{
@@ -77,7 +82,8 @@
 			"edition_uri": "http://www.worldcat.org/oclc/243873605",
 			"ebook_url": "http://example.com",
 			"work_format": 2,
-			"slug": "dial"
+			"slug": "dial",
+			"updated_at": "2020-03-27T13:26:15Z"
 		}
 	},
 	{

--- a/mep/books/management/commands/export_books.py
+++ b/mep/books/management/commands/export_books.py
@@ -1,8 +1,9 @@
 '''
-Manage command to export member data for use by others.
+Manage command to export book data for use by others.
 
-Generates a CSV and JSON file including details on every library member in the
-database, with summary details and coordinates for associated addresses.
+Generates a CSV and JSON file including details on every book in the
+database, with bibliographic details and counts for all events, borrows,
+and purchases.
 
 '''
 

--- a/mep/books/management/commands/export_books.py
+++ b/mep/books/management/commands/export_books.py
@@ -26,6 +26,8 @@ class Command(BaseExport):
     creator_types = CreatorType.objects.all().filter(creator__isnull=False) \
                                .distinct() \
                                .values_list('name', flat=True)
+    # NOTE: might want to move csv fields this into a method so we don't
+    # query the database at load time (but maybe only a problem for tests)
 
     csv_fields = ['uri', 'title'] + \
         [creator.lower() for creator in creator_types] + [

--- a/mep/books/management/commands/export_books.py
+++ b/mep/books/management/commands/export_books.py
@@ -48,7 +48,9 @@ class Command(BaseExport):
         return 'books'
 
     def get_queryset(self):
-        '''prefetch and annotate to make the export more efficient'''
+        '''Retrieve all books, with creators prefetched and annotations
+        for event counts to make the export more efficient; sort by year
+        (missing last) and then title.'''
         return super().get_queryset().prefetch_related('creator_set') \
                       .count_events() \
                       .order_by(F('year').asc(nulls_last=True), 'title')

--- a/mep/books/management/commands/export_books.py
+++ b/mep/books/management/commands/export_books.py
@@ -92,10 +92,9 @@ class Command(BaseExport):
             data['notes'] = work.public_notes
 
         # always include event counts
-        # for efficiency, use queryset annotation counts instead of model prop
-        data['event count'] = work.event__count
-        data['borrow count'] = work.event__borrow__count
-        data['purchase count'] = work.event__purchase__count
+        data['event count'] = work.event_count
+        data['borrow count'] = work.borrow_count
+        data['purchase count'] = work.purchase_count
         # date last modified
         data['updated'] = work.updated_at.isoformat()
 

--- a/mep/books/models.py
+++ b/mep/books/models.py
@@ -604,6 +604,9 @@ class CreatorType(Named, Notable):
     order = models.PositiveSmallIntegerField(
         help_text='order in which creator types will be listed')
 
+    class Meta:
+        ordering = ['order']
+
 
 class Creator(Notable):
     creator_type = models.ForeignKey(CreatorType, on_delete=models.CASCADE)

--- a/mep/books/models.py
+++ b/mep/books/models.py
@@ -220,6 +220,17 @@ class WorkSignalHandlers:
             ModelIndexable.index_items(works)
 
 
+class WorkQuerySet(models.QuerySet):
+    '''Custom :class:`models.QuerySet` for :class:`Work`'''
+
+    def count_events(self):
+        '''Annotate the queryset with counts for events, borrows,
+        and purchases.'''
+        return self.annotate(models.Count('event', distinct=True),
+                             models.Count('event__borrow', distinct=True),
+                             models.Count('event__purchase', distinct=True))
+
+
 class Work(Notable, ModelIndexable):
     '''Work record for an item that circulated in the library or was
     other referenced in library activities.'''
@@ -272,6 +283,9 @@ class Work(Notable, ModelIndexable):
         'Editing will change the public, citable URL for books.')
     # NOTE: null=true required to avoid validation error
     # when submitting admin edit form with no slug
+
+    # override default manager with customized version
+    objects = WorkQuerySet.as_manager()
 
     def save(self, *args, **kwargs):
         # override save to ensure mep ID is None rather than empty string

--- a/mep/common/utils.py
+++ b/mep/common/utils.py
@@ -41,10 +41,11 @@ def absolutize_url(local_url, request=None):
 def alpha_pagelabels(paginator, objects, attr_meth):
     """Generate abbreviated, alphabetical page labels for pagination items.
     Label format should be something like 'Ab - Ad', 'Ard - Art'.
+
     :param paginator: a django paginator
     :param objects: the complete list of objects paginated by the paginator
     :param attr_meth: method or lambda to retrieve the attribute on the
-        object that shoudl be used for page labels
+        object that should be used for page labels
     :returns: :class:`~collections.OrderedDict` where keys are page
         numbers and values are page labels
     """

--- a/mep/people/management/commands/export_books.py
+++ b/mep/people/management/commands/export_books.py
@@ -8,6 +8,8 @@ database, with summary details and coordinates for associated addresses.
 
 from collections import OrderedDict
 
+from django.db.models import F
+
 from mep.books.models import CreatorType, Work
 from mep.common.management.export import BaseExport
 from mep.common.utils import absolutize_url
@@ -48,7 +50,8 @@ class Command(BaseExport):
     def get_queryset(self):
         '''prefetch and annotate to make the export more efficient'''
         return super().get_queryset().prefetch_related('creator_set') \
-                      .count_events()
+                      .count_events() \
+                      .order_by(F('year').asc(nulls_last=True), 'title')
 
     def get_object_data(self, work):
         '''

--- a/mep/people/management/commands/export_books.py
+++ b/mep/people/management/commands/export_books.py
@@ -1,0 +1,112 @@
+'''
+Manage command to export member data for use by others.
+
+Generates a CSV and JSON file including details on every library member in the
+database, with summary details and coordinates for associated addresses.
+
+'''
+
+from collections import OrderedDict
+
+from django.db.models import Count
+
+from mep.books.models import CreatorType, Work
+from mep.common.management.export import BaseExport
+from mep.common.utils import absolutize_url
+
+
+class Command(BaseExport):
+    '''Export book data.'''
+    help = __doc__
+
+    model = Work
+
+    # get a current list of creator types from the database
+    # - only include types with creators associated
+    creator_types = CreatorType.objects.all().filter(creator__isnull=False) \
+                               .distinct() \
+                               .values_list('name', flat=True)
+    print(creator_types)
+
+    csv_fields = ['uri', 'title'] + \
+        [creator.lower() for creator in creator_types] + [
+        "year",
+        "format",
+        "identified",
+        "work uri",
+        "edition uri",
+        "ebook url",
+        "volumes/issues",
+        "notes",
+        "event count",
+        "borrow count",
+        "purchase count",
+        "updated"
+    ]
+
+    def get_base_filename(self):
+        '''use "books" instead of "works" since it's more accessible'''
+        return 'books'
+
+    def get_queryset(self):
+        '''prefetch and annotate to make the export more efficient'''
+        # NOTE: same queryset as used for django admin csv export,
+        # is there a way to share? move to custom queryset with methods
+        return super().get_queryset().prefetch_related('creator_set') \
+            .annotate(Count('event', distinct=True),
+                      Count('event__borrow', distinct=True),
+                      Count('event__purchase', distinct=True))
+
+    def get_object_data(self, work):
+        '''
+        Generate dictionary of data to export for a single
+        :class:`~mep.books.models.Work`
+        '''
+        # required properties
+        data = OrderedDict([
+            ('uri', absolutize_url(work.get_absolute_url())),
+            ('title', work.title),
+        ])
+        data.update(self.creator_info(work))
+        if work.year:
+            data['year'] = work.year
+        # format is not currently set for all items
+        if work.work_format:
+            data['format'] = work.work_format.name
+
+        # identified: true unless work is marked as uncertain
+        data['identified'] = not work.is_uncertain
+
+        if work.uri:
+            data['work uri'] = work.uri
+        if work.edition_uri:
+            data['edition uri'] = work.edition_uri
+        if work.ebook_url:
+            data['ebook url'] = work.ebook_url
+        # text listing of volumes/issues
+        if work.edition_set.exists():
+            data['volumes/issues'] = [vol.display_text() for vol in
+                                      work.edition_set.all()]
+        # public notes
+        if work.public_notes:
+            data['notes'] = work.public_notes
+
+        # always include event counts
+        # for efficiency, use queryset annotation counts instead of model prop
+        data['event count'] = work.event__count
+        data['borrow count'] = work.event__borrow__count
+        data['purchase count'] = work.event__purchase__count
+        # date last modified
+        data['updated'] = work.updated_at.isoformat()
+
+        return data
+
+    def creator_info(self, work):
+        '''Add information about authors, editors, etc based on creators
+        associated with this work.'''
+        info = OrderedDict()
+        for creator_type in self.creator_types:
+            creators = work.creator_by_type(creator_type)
+            if creators:
+                info[creator_type.lower()] = [c.sort_name for c in creators]
+        return info

--- a/mep/people/management/commands/export_members.py
+++ b/mep/people/management/commands/export_members.py
@@ -8,6 +8,8 @@ database, with summary details and coordinates for associated addresses.
 
 from collections import OrderedDict
 
+from django.db.models import Count
+
 from mep.common.management.export import BaseExport
 from mep.common.templatetags.mep_tags import domain
 from mep.common.utils import absolutize_url
@@ -43,10 +45,10 @@ class Command(BaseExport):
         '''set the filename to "members.csv" since it's a subset of people'''
         return 'members'
 
-    def get_object_data(self, obj: Person):
+    def get_object_data(self, obj):
         '''
         Generate dictionary of data to export for a single
-        :class:`~mep.accounts.models.Person`
+        :class:`~mep.people.models.Person`
         '''
         # required properties
         data = OrderedDict([
@@ -99,5 +101,5 @@ class Command(BaseExport):
         # add public notes
         if obj.public_notes:
             data['notes'] = obj.public_notes
-    
+
         return data

--- a/mep/people/management/commands/export_members.py
+++ b/mep/people/management/commands/export_members.py
@@ -8,8 +8,6 @@ database, with summary details and coordinates for associated addresses.
 
 from collections import OrderedDict
 
-from django.db.models import Count
-
 from mep.common.management.export import BaseExport
 from mep.common.templatetags.mep_tags import domain
 from mep.common.utils import absolutize_url
@@ -34,7 +32,8 @@ class Command(BaseExport):
         # related location
         'addresses', 'coordinates',
         # generic
-        'notes'
+        'notes',
+        'updated'
     ]
 
     def get_queryset(self):
@@ -101,5 +100,8 @@ class Command(BaseExport):
         # add public notes
         if obj.public_notes:
             data['notes'] = obj.public_notes
+
+        # last modified
+        data['updated'] = obj.updated_at.isoformat()
 
         return data

--- a/mep/people/tests/test_people_commands.py
+++ b/mep/people/tests/test_people_commands.py
@@ -2,8 +2,8 @@ from io import StringIO
 
 from django.test import TestCase
 
-from mep.people.models import Person
 from mep.people.management.commands import export_members
+from mep.people.models import Person
 
 
 class TestExportMembers(TestCase):
@@ -16,10 +16,10 @@ class TestExportMembers(TestCase):
     def test_get_queryset(self):
         # queryset should only include library members
         member = Person.objects.get(pk=189)  # francisque gay, member
-        author = Person.objects.get(pk=7152) # aeschylus, non-member
+        author = Person.objects.get(pk=7152)  # aeschylus, non-member
         qs = self.cmd.get_queryset()
-        self.assertTrue(member in qs)
-        self.assertFalse(author in qs)
+        assert member in qs
+        assert author not in qs
 
     def test_get_object_data(self):
         # fetch some example people from fixture & call get_object_data
@@ -29,22 +29,25 @@ class TestExportMembers(TestCase):
         hemingway_data = self.cmd.get_object_data(hemingway)
 
         # check some basic data
-        self.assertEqual(gay_data['name'], 'Francisque Gay')
-        self.assertEqual(gay_data['gender'], 'Male')
-        self.assertEqual(gay_data['birth year'], 1885)
-        self.assertEqual(hemingway_data['sort name'], 'Hemingway, Ernest')
-        self.assertEqual(hemingway_data['death year'], 1961)
-        self.assertFalse('title' in hemingway_data) # empty fields not present
+        assert gay_data['name'] == 'Francisque Gay'
+        assert gay_data['gender'] == 'Male'
+        assert gay_data['birth year'] == 1885
+        assert hemingway_data['sort name'] == 'Hemingway, Ernest'
+        assert hemingway_data['death year'] == 1961
+        assert 'title' not in hemingway_data   # empty fields not present
 
         # check nationalities
-        self.assertTrue('France' in gay_data['nationalities'])
-        self.assertTrue('United States' in hemingway_data['nationalities'])
+        assert 'France' in gay_data['nationalities']
+        assert 'United States' in hemingway_data['nationalities']
 
         # check viaf & wikipedia urls
-        self.assertEqual(hemingway_data['wikipedia url'],
-                         'https://en.wikipedia.org/wiki/Ernest_Hemingway')
-        self.assertEqual(gay_data['viaf url'], 'http://viaf.org/viaf/9857613')
+        assert hemingway_data['wikipedia url'] == \
+            'https://en.wikipedia.org/wiki/Ernest_Hemingway'
+        assert gay_data['viaf url'] == 'http://viaf.org/viaf/9857613'
 
         # check addresses & coordinates
-        self.assertTrue('3 Rue Garancière, Paris' in gay_data['addresses'])
-        self.assertTrue('48.85101, 2.33590' in gay_data ['coordinates'])
+        assert '3 Rue Garancière, Paris' in gay_data['addresses']
+        assert '48.85101, 2.33590' in gay_data['coordinates']
+
+        assert gay_data['updated'] == gay.updated_at.isoformat()
+        assert hemingway_data['updated'] == hemingway.updated_at.isoformat()

--- a/sphinx-docs/codedocs.rst
+++ b/sphinx-docs/codedocs.rst
@@ -14,6 +14,22 @@ Models
 .. automodule:: mep.common.models
     :members:
 
+Utils
+^^^^^
+.. automodule:: mep.common.utils
+    :members:
+
+Views
+^^^^^
+.. automodule:: mep.common.views
+    :members:
+
+Validators
+^^^^^^^^^^
+.. automodule:: mep.common.validators
+    :members:
+
+
 Accounts
 --------
 .. automodule:: mep.accounts
@@ -24,6 +40,13 @@ Models
 .. automodule:: mep.accounts.models
     :members:
 
+Partial Dates
+^^^^^^^^^^^^^
+
+.. automodule:: mep.accounts.partial_date
+    :members:
+
+
 Manage Commands
 ^^^^^^^^^^^^^^^
 
@@ -31,6 +54,11 @@ report timegaps
 ~~~~~~~~~~~~~~~
 
 .. automodule:: mep.accounts.management.commands.report_timegaps
+
+export events
+~~~~~~~~~~~~~
+
+.. automodule:: mep.accounts.management.commands.export_events
 
 
 Books
@@ -42,6 +70,25 @@ Models
 ^^^^^^
 .. automodule:: mep.books.models
     :members:
+
+Views
+^^^^^^
+.. automodule:: mep.books.views
+    :members:
+
+Utils
+^^^^^
+.. automodule:: mep.books.utils
+    :members:
+
+Manage Commands
+^^^^^^^^^^^^^^^
+
+export books
+~~~~~~~~~~~~~
+
+.. automodule:: mep.books.management.commands.export_books
+
 
 People
 ------
@@ -72,6 +119,15 @@ Admin
 ^^^^^^
 .. automodule:: mep.people.admin
     :members:
+
+Manage Commands
+^^^^^^^^^^^^^^^
+
+export members
+~~~~~~~~~~~~~~
+
+.. automodule:: mep.people.management.commands.export_members
+
 
 Footnotes
 ---------


### PR DESCRIPTION
New book export manage command.

I ended up reusing some queryset annotation we already had in the book admin for event counts, so I made a work queryset class to make it reusable. It isn't tested directly, but should be tested by the existing admin tests.

Minor updates to event/member exports:
- include updated timestamp on member export
- include new book urls in event export

