### PR TITLE
Include all card images with member events in card member gallery & card detail

### DIFF
--- a/mep/people/tests/test_views.py
+++ b/mep/people/tests/test_views.py
@@ -1377,7 +1377,7 @@ class TestMemberCardList(TestCase):
             self.view.get_queryset()
 
         self.view.kwargs = {'slug': 'stein-gertrude'}
-        canvas_ids = list(self.view.get_queryset().values_list('pk', flat=True))
+        canvas_ids = list(c.pk for c in self.view.get_queryset())
         # member should be stored on the view
         assert self.view.member == Person.objects.get(slug='stein-gertrude')
         # queryset should be canvas ids for footnotes associated with Stein
@@ -1553,7 +1553,8 @@ class TestMemberCardDetail(TestCase):
         # should have a page object & paginator stored in context
         assert isinstance(context['card_page'].paginator, Paginator)
         # list of other cards (canvases) stored in context
-        assert context['cards'] == self.view.get_object().manifest.canvases
+        assert list(context['cards']) == \
+            list(self.view.member.account_set.first().member_card_images())
 
     def test_view_template(self):
         member = Person.objects.get(slug='stein-gertrude')

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -496,7 +496,7 @@ class MemberCardDetail(DetailView, RdfViewMixin):
                 card = image
                 break
         if not card:
-            # 404 if we didn't find the requested it
+            # 404 if we didn't find the requested card
             raise Http404
 
         # use card dates for label

--- a/mep/people/views.py
+++ b/mep/people/views.py
@@ -452,9 +452,15 @@ class MemberCardList(ListView, RdfViewMixin):
                                         slug=self.kwargs['slug'])
         # find all canvas objects for this person, via manifest
         # associated with lending card bibliography
-        return super().get_queryset() \
-                      .filter(manifest__bibliography__account__persons__slug=self.kwargs['slug']) \
-                      .order_by('order')
+
+        card_filter = (
+            Q(manifest__bibliography__account__persons__pk=self.member.pk) |
+            Q(footnote__events__account__persons__pk=self.member.pk) |
+            Q(footnote__borrows__account__persons__pk=self.member.pk) |
+            Q(footnote__purchases__account__persons__pk=self.member.pk))
+
+        return super().get_queryset().filter(card_filter) \
+                      .distinct().order_by('order')
 
     def get_absolute_url(self):
         '''Full URI for member card list page.'''


### PR DESCRIPTION
Adds a new method on account to find all card images for a member — either images associated with the manifest that represent the card for the account (which could include blanks) OR cards associated via footnotes on events for that account.

Uses the new method in member card list and member card detail view.