### PR TITLE
Revise book search configuration to address stop word issue

### DIFF
--- a/mep/books/views.py
+++ b/mep/books/views.py
@@ -240,17 +240,18 @@ class WorkDetail(WorkLastModifiedListMixin, DetailView, RdfViewMixin):
             description = 'By %s' % ','.join(
                 [a.name for a in self.object.authors])
         if self.object.year:
-            description += ', %s.\n ' % self.object.year
-        if self.object.public_notes:
-            description += self.object.public_notes
+            description += ', %s' % self.object.year
+        description += '. '
 
         # text-only readable version of membership years for meta description
         circ_years = strip_tags(as_ranges(self.object.event_years)
                                 .replace('</span>', ',')).rstrip(',')
 
-        description += '%d event%s in %s.' % \
+        description += '%d event%s in %s. ' % \
             (self.object.event_count,
              '' if self.object.event_count == 1 else 's', circ_years)
+        if self.object.public_notes:
+            description += self.object.public_notes
 
         context.update({
             'page_title': self.object.title,

--- a/mep/common/solr.py
+++ b/mep/common/solr.py
@@ -25,7 +25,7 @@ class SolrSchema(schema.SolrSchema):
         'name_t': 'name_ngram',
         'sort_name_t': 'name_ngram',
         # stemmed version of titles for searching
-        'title_t': ['title_txt_en', 'title_txt_en_nostem'],
+        'title_t': ['title_txt_ens', 'title_txt_en_nostem'],
         # author names without stop words
         'authors_t': 'authors_txt_en_nostem'
     }

--- a/mep/common/solr.py
+++ b/mep/common/solr.py
@@ -25,5 +25,7 @@ class SolrSchema(schema.SolrSchema):
         'name_t': 'name_ngram',
         'sort_name_t': 'name_ngram',
         # stemmed version of titles for searching
-        'title_t': 'title_txt_en',
+        'title_t': ['title_txt_en', 'title_txt_en_nostem'],
+        # author names without stop words
+        'authors_t': 'authors_txt_en_nostem'
     }

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -441,7 +441,7 @@
     </fieldType>
 
     <!-- A text field with defaults appropriate for English but no stemming. -->
-    <dynamicField name="*_txt_en_nostem" type="text_en_nostem" indexed="true"  stored="false"/>
+    <dynamicField name="*_txt_en_nostem" type="text_en_nostem" indexed="true"  stored="false" multiValued="true"/>
     <fieldType name="text_en_nostem" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -402,6 +402,7 @@
          finally applies Porter's stemming.  The query time analyzer
          also applies synonyms from synonyms.txt. -->
     <dynamicField name="*_txt_en" type="text_en"  indexed="true"  stored="true"/>
+    <dynamicField name="*_txt_ens" type="text_en"  indexed="true"  stored="false" multiValued="true"/>
     <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -440,6 +440,32 @@
       </analyzer>
     </fieldType>
 
+    <!-- A text field with defaults appropriate for English but no stemming. -->
+    <dynamicField name="*_txt_en_nostem" type="text_en_nostem" indexed="true"  stored="false"/>
+    <fieldType name="text_en_nostem" class="solr.TextField" positionIncrementGap="100">
+      <analyzer type="index">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.StopFilterFactory"
+                ignoreCase="true"
+                words="lang/stopwords_en.txt"
+            />
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.EnglishPossessiveFilterFactory"/>
+        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.StopFilterFactory"
+                ignoreCase="true"
+                words="lang/stopwords_en.txt"
+        />
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.EnglishPossessiveFilterFactory"/>
+        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+      </analyzer>
+    </fieldType>
+
     <!-- A text field with defaults appropriate for English, plus
          aggressive word-splitting and autophrase features enabled.
          This field is just like text_en, except it adds

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -767,9 +767,11 @@
 
       <!-- bib metadata search pseudo field for books -->
       <str name="bib_qf">
-        authors_t^200
-        title_t^60
+        authors_txt_en_nostem^200
+        title_txt_en_nostem^60
         title_txt_en^40
+        authors_t
+        title_t
         creators_t^20
         format_s_lower^10
         notes_txt_en

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -768,10 +768,10 @@
       <!-- bib metadata search pseudo field for books -->
       <str name="bib_qf">
         authors_txt_en_nostem^200
-        title_txt_en_nostem^60
-        title_txt_en^40
-        authors_t
-        title_t
+        title_txt_en_nostem^100
+        title_txt_en^80
+        authors_t^60
+        title_t^40
         creators_t^20
         format_s_lower^10
         notes_txt_en

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -769,7 +769,7 @@
       <str name="bib_qf">
         authors_txt_en_nostem^200
         title_txt_en_nostem^100
-        title_txt_en^80
+        title_txt_ens^80
         authors_t^60
         title_t^40
         creators_t^20


### PR DESCRIPTION
- configures a new "no-stem" field definition with stopword filtering but no stemming
- use the new nostem field as a copy field for both author and title
- prioritizes the nostem field over the other variants
- decreases boosting on the existing title and author field variants that include stopwords


(Ignore the meta description change, I accidentally put it here instead of develop.)