### PR TITLE
Bugfix/tab navigable hidden menu

### DIFF
--- a/srcmedia/scss/common/_nav.scss
+++ b/srcmedia/scss/common/_nav.scss
@@ -79,14 +79,12 @@
         width: 100vw;
         height: 100vh;
         opacity: 0;
-        display: none;
         background: $white;
         transition: opacity 0.5s ease;
         padding-top: 0.5rem;
 
         &:target { // when menu button is clicked
             opacity: 1;
-            display: block;
             z-index: 100;
             pointer-events: all;
         }

--- a/srcmedia/scss/common/_nav.scss
+++ b/srcmedia/scss/common/_nav.scss
@@ -79,12 +79,14 @@
         width: 100vw;
         height: 100vh;
         opacity: 0;
+        display: none;
         background: $white;
         transition: opacity 0.5s ease;
         padding-top: 0.5rem;
 
         &:target { // when menu button is clicked
             opacity: 1;
+            display: block;
             z-index: 100;
             pointer-events: all;
         }

--- a/srcmedia/ts/components/MainMenu.ts
+++ b/srcmedia/ts/components/MainMenu.ts
@@ -23,8 +23,8 @@ export default class MainMenu {
         event.preventDefault()
         this.element.style.zIndex = '100'
         this.element.style.opacity = '1'
-        this.element.style.display = 'block'
         this.element.style.pointerEvents = 'all'
+        this.element.setAttribute('tabindex', '0')
         this.element.removeAttribute('aria-hidden')
         document.body.style.overflowY = 'hidden'
         return new Promise(resolve => setTimeout(resolve, this.transitionDuration))
@@ -40,8 +40,8 @@ export default class MainMenu {
         event.preventDefault()
         this.element.style.zIndex = '-100'
         this.element.style.opacity = '0'
-        this.element.style.display = 'none'
         this.element.style.pointerEvents = 'none'
+        this.element.setAttribute('tabindex', '-1')
         this.element.setAttribute('aria-hidden', 'true')
         document.body.style.overflowY = ''
         return new Promise(resolve => setTimeout(resolve, this.transitionDuration))

--- a/srcmedia/ts/components/MainMenu.ts
+++ b/srcmedia/ts/components/MainMenu.ts
@@ -23,6 +23,7 @@ export default class MainMenu {
         event.preventDefault()
         this.element.style.zIndex = '100'
         this.element.style.opacity = '1'
+        this.element.style.display = 'block'
         this.element.style.pointerEvents = 'all'
         this.element.removeAttribute('aria-hidden')
         document.body.style.overflowY = 'hidden'
@@ -39,6 +40,7 @@ export default class MainMenu {
         event.preventDefault()
         this.element.style.zIndex = '-100'
         this.element.style.opacity = '0'
+        this.element.style.display = 'none'
         this.element.style.pointerEvents = 'none'
         this.element.setAttribute('aria-hidden', 'true')
         document.body.style.overflowY = ''


### PR DESCRIPTION
Set menu to `display: none` as well as `opacity: 1` when it should be hidden, so that it isn't tab navigable when closed.