### PR TITLE
Add datapackages for data exports

### DIFF
--- a/data-export-meta/README.rst
+++ b/data-export-meta/README.rst
@@ -1,0 +1,8 @@
+Data exports
+============
+
+This directory contains [Frictionless data](https://frictionlessdata.io/) [data package](https://specs.frictionlessdata.io/data-package/)
+files to describe and validate Project data exports.
+
+They are currently generated and maintained manually; they should be updated
+for deposit with revised data exports as needed.

--- a/data-export-meta/books-datapackage.json
+++ b/data-export-meta/books-datapackage.json
@@ -1,0 +1,154 @@
+{
+  "profile": "tabular-data-package",
+  "title": "Shakespeare and Company Project: Lending Library Books",
+  "homepage": "https://shakespeareandco.princeton.edu/about/data/",
+  "version": "1.0.0",
+  "image": "https://shakespeareandco.princeton.edu/static/img/social.png",
+  "licenses": [{
+    "name": "CC-BY-4.0",
+    "path": "https://creativecommons.org/licenses/by/4.0/",
+    "title": "Creative Commons Attribution 4.0"
+  }],
+  "resources": [
+    {
+      "path": "books.csv",
+      "profile": "tabular-data-resource",
+      "name": "books",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "encoding": "utf-8-sig",
+      "schema": {
+        "fields": [
+          {
+            "name": "uri",
+            "type": "string",
+            "format": "uri",
+            "constraints": {
+              "required": true
+            }
+          },
+          {
+            "name": "title",
+            "type": "string",
+            "format": "default",
+            "constraints": {
+              "required": true
+            }
+          },
+          {
+            "name": "author",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "editor",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "contributor",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "translator",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "illustrator",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "introduction",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "preface",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "photographer",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "year",
+            "type": "year",
+            "format": "default"
+          },
+          {
+            "name": "format",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "uncertain",
+            "type": "boolean",
+            "format": "default"
+          },
+          {
+            "name": "ebook_url",
+            "type": "string",
+            "format": "uri"
+          },
+          {
+            "name": "volumes_issues",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "notes",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "event_count",
+            "type": "integer",
+            "format": "default"
+          },
+          {
+            "name": "borrow_count",
+            "type": "integer",
+            "format": "default"
+          },
+          {
+            "name": "purchase_count",
+            "type": "integer",
+            "format": "default"
+          },
+          {
+            "name": "circulation_years",
+            "type": "string",
+            "rdfType": "https://schema.org/ItemList",
+            "format": "default",
+            "constraints": {
+              "pattern": "(\\d{4})?(;\\d{4})*"
+            }
+          },
+          {
+            "name": "updated",
+            "type": "datetime",
+            "format": "%Y-%m-%dT%H:%M:%S+00:00"
+          }
+        ],
+        "missingValues": [
+          ""
+        ],
+        "primaryKey": "uri"
+      }
+    }
+  ]
+}

--- a/data-export-meta/events-datapackage.json
+++ b/data-export-meta/events-datapackage.json
@@ -1,0 +1,172 @@
+{
+  "profile": "tabular-data-package",
+  "title": "Shakespeare and Company Project: Lending Library Events",
+  "homepage": "https://shakespeareandco.princeton.edu/about/data/",
+  "version": "1.0.0",
+  "image": "https://shakespeareandco.princeton.edu/static/img/social.png",
+  "licenses": [{
+    "name": "CC-BY-4.0",
+    "path": "https://creativecommons.org/licenses/by/4.0/",
+    "title": "Creative Commons Attribution 4.0"
+  }],
+  "resources": [
+    {
+      "path": "events.csv",
+      "profile": "tabular-data-resource",
+      "name": "events",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "encoding": "utf-8-sig",
+      "schema": {
+        "fields": [
+          {
+            "name": "event_type",
+            "type": "string",
+            "format": "default",
+            "constraints": {
+              "required": true
+            }
+          },
+          {
+            "name": "start_date",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/Date",
+            "constraints": {
+              "pattern": "(\\d{4}|-)?(?:-([01]\\d))?(?:-([0-3]\\d))?"
+            }
+          },
+          {
+            "name": "end_date",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/Date",
+            "constraints": {
+              "pattern": "(\\d{4}|-)?(?:-([01]\\d))?(?:-([0-3]\\d))?"
+            }
+          },
+          {
+            "name": "member_URIs",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "member_names",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "member_sort_names",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "subscription_price_paid",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "subscription_deposit",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "subscription_duration",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "subscription_duration_days",
+            "type": "integer",
+            "format": "default"
+          },
+          {
+            "name": "subscription_volumes",
+            "type": "integer",
+            "format": "default"
+          },
+          {
+            "name": "subscription_category",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "subscription_purchase_date",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/Date",
+            "constraints": {
+              "pattern": "(\\d{4}|-)?(?:-([01]\\d))?(?:-([0-3]\\d))?"
+            }
+          },
+          {
+            "name": "reimbursement_refund",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "borrow_status",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "purchase_price",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "item_uri",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "item_title",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "item_volume",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "item_authors",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "item_year",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "item_notes",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "source_citation",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "source_manifest",
+            "type": "string",
+            "format": "uri"
+          },
+          {
+            "name": "source_image",
+            "type": "string",
+            "format": "uri"
+          }
+        ],
+        "missingValues": [
+          ""
+        ]
+      }
+    }
+  ]
+}

--- a/data-export-meta/events-datapackage.json
+++ b/data-export-meta/events-datapackage.json
@@ -46,7 +46,7 @@
             }
           },
           {
-            "name": "member_URIs",
+            "name": "member_uris",
             "type": "string",
             "format": "default",
             "rdfType": "https://schema.org/ItemList"

--- a/data-export-meta/events-datapackage.json
+++ b/data-export-meta/events-datapackage.json
@@ -65,13 +65,15 @@
           },
           {
             "name": "subscription_price_paid",
-            "type": "string",
-            "format": "default"
+            "type": "number",
+            "format": "default",
+            "rdfType": "https://schema.org/MonetaryAmount"
           },
           {
             "name": "subscription_deposit",
-            "type": "string",
-            "format": "default"
+            "type": "number",
+            "format": "default",
+            "rdfType": "https://schema.org/MonetaryAmount"
           },
           {
             "name": "subscription_duration",
@@ -104,8 +106,9 @@
           },
           {
             "name": "reimbursement_refund",
-            "type": "string",
-            "format": "default"
+            "type": "number",
+            "format": "default",
+            "rdfType": "https://schema.org/MonetaryAmount"
           },
           {
             "name": "borrow_status",
@@ -114,6 +117,12 @@
           },
           {
             "name": "purchase_price",
+            "type": "number",
+            "format": "default",
+            "rdfType": "https://schema.org/MonetaryAmount"
+          },
+          {
+            "name": "currency",
             "type": "string",
             "format": "default"
           },

--- a/data-export-meta/full-datapackage.json
+++ b/data-export-meta/full-datapackage.json
@@ -1,0 +1,472 @@
+{
+  "profile": "tabular-data-package",
+  "title": "Shakespeare and Company Project: Lending Library Members, Events, and Books",
+  "homepage": "https://shakespeareandco.princeton.edu/about/data/",
+  "version": "1.0.0",
+  "image": "https://shakespeareandco.princeton.edu/static/img/social.png",
+  "licenses": [
+    {
+      "name": "CC-BY-4.0",
+      "path": "https://creativecommons.org/licenses/by/4.0/",
+      "title": "Creative Commons Attribution 4.0"
+    }
+  ],
+  "resources": [
+    {
+      "path": "members.csv",
+      "profile": "tabular-data-resource",
+      "name": "members",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "encoding": "utf-8-sig",
+      "schema": {
+        "fields": [
+          {
+            "name": "uri",
+            "type": "string",
+            "format": "uri",
+            "constraints": {
+              "required": true
+            }
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "format": "default",
+            "constraints": {
+              "required": true
+            }
+          },
+          {
+            "name": "sort_name",
+            "type": "string",
+            "format": "default",
+            "constraints": {
+              "required": true
+            }
+          },
+          {
+            "name": "title",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "gender",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "is_organization",
+            "type": "boolean",
+            "format": "default"
+          },
+          {
+            "name": "has_card",
+            "type": "boolean",
+            "format": "default"
+          },
+          {
+            "name": "birth_year",
+            "type": "year",
+            "format": "default"
+          },
+          {
+            "name": "death_year",
+            "type": "year",
+            "format": "default"
+          },
+          {
+            "name": "membership_years",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList",
+            "constraints": {
+              "pattern": "\\d{4}(;\\d{4})*"
+            }
+          },
+          {
+            "name": "viaf_url",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "wikipedia_url",
+            "type": "string",
+            "format": "uri"
+          },
+          {
+            "name": "nationalities",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "addresses",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "postal_codes",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList",
+            "constraints": {
+              "pattern": "(\\d{5}|[A-Z \\d]+|)(;(\\d{5}|[A-Z \\d]+|))*"
+            }
+          },
+          {
+            "name": "arrondissements",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList",
+            "constraints": {
+              "pattern": "(\\d{1,2})?(;(\\d{1,2})?)*"
+            }
+          },
+          {
+            "name": "coordinates",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "notes",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "updated",
+            "type": "datetime",
+            "format": "%Y-%m-%dT%H:%M:%S+00:00"
+          }
+        ],
+        "missingValues": [
+          ""
+        ],
+        "primaryKey": "uri"
+      }
+    },
+    {
+      "path": "books.csv",
+      "profile": "tabular-data-resource",
+      "name": "books",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "encoding": "utf-8-sig",
+      "schema": {
+        "fields": [
+          {
+            "name": "uri",
+            "type": "string",
+            "format": "uri",
+            "constraints": {
+              "required": true
+            }
+          },
+          {
+            "name": "title",
+            "type": "string",
+            "format": "default",
+            "constraints": {
+              "required": true
+            }
+          },
+          {
+            "name": "author",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "editor",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "contributor",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "translator",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "illustrator",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "introduction",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "preface",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "photographer",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "year",
+            "type": "year",
+            "format": "default"
+          },
+          {
+            "name": "format",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "uncertain",
+            "type": "boolean",
+            "format": "default"
+          },
+          {
+            "name": "ebook_url",
+            "type": "string",
+            "format": "uri"
+          },
+          {
+            "name": "volumes_issues",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "notes",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "event_count",
+            "type": "integer",
+            "format": "default"
+          },
+          {
+            "name": "borrow_count",
+            "type": "integer",
+            "format": "default"
+          },
+          {
+            "name": "purchase_count",
+            "type": "integer",
+            "format": "default"
+          },
+          {
+            "name": "circulation_years",
+            "type": "string",
+            "rdfType": "https://schema.org/ItemList",
+            "format": "default",
+            "constraints": {
+              "pattern": "(\\d{4})?(;\\d{4})*"
+            }
+          },
+          {
+            "name": "updated",
+            "type": "datetime",
+            "format": "%Y-%m-%dT%H:%M:%S+00:00"
+          }
+        ],
+        "missingValues": [
+          ""
+        ],
+        "primaryKey": "uri"
+      }
+    },
+    {
+      "path": "events.csv",
+      "profile": "tabular-data-resource",
+      "name": "events",
+      "format": "csv",
+      "mediatype": "text/csv",
+      "encoding": "utf-8-sig",
+      "schema": {
+        "fields": [
+          {
+            "name": "event_type",
+            "type": "string",
+            "format": "default",
+            "constraints": {
+              "required": true
+            }
+          },
+          {
+            "name": "start_date",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/Date",
+            "constraints": {
+              "pattern": "(\\d{4}|-)?(?:-([01]\\d))?(?:-([0-3]\\d))?"
+            }
+          },
+          {
+            "name": "end_date",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/Date",
+            "constraints": {
+              "pattern": "(\\d{4}|-)?(?:-([01]\\d))?(?:-([0-3]\\d))?"
+            }
+          },
+          {
+            "name": "member_URIs",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "member_names",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "member_sort_names",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/ItemList"
+          },
+          {
+            "name": "subscription_price_paid",
+            "type": "number",
+            "format": "default",
+            "rdfType": "https://schema.org/MonetaryAmount"
+          },
+          {
+            "name": "subscription_deposit",
+            "type": "number",
+            "format": "default",
+            "rdfType": "https://schema.org/MonetaryAmount"
+          },
+          {
+            "name": "subscription_duration",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "subscription_duration_days",
+            "type": "integer",
+            "format": "default"
+          },
+          {
+            "name": "subscription_volumes",
+            "type": "integer",
+            "format": "default"
+          },
+          {
+            "name": "subscription_category",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "subscription_purchase_date",
+            "type": "string",
+            "format": "default",
+            "rdfType": "https://schema.org/Date",
+            "constraints": {
+              "pattern": "(\\d{4}|-)?(?:-([01]\\d))?(?:-([0-3]\\d))?"
+            }
+          },
+          {
+            "name": "reimbursement_refund",
+            "type": "number",
+            "format": "default",
+            "rdfType": "https://schema.org/MonetaryAmount"
+          },
+          {
+            "name": "borrow_status",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "purchase_price",
+            "type": "number",
+            "format": "default",
+            "rdfType": "https://schema.org/MonetaryAmount"
+          },
+          {
+            "name": "currency",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "item_uri",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "item_title",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "item_volume",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "item_authors",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "item_year",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "item_notes",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "source_citation",
+            "type": "string",
+            "format": "default"
+          },
+          {
+            "name": "source_manifest",
+            "type": "string",
+            "format": "uri"
+          },
+          {
+            "name": "source_image",
+            "type": "string",
+            "format": "uri"
+          }
+        ],
+        "missingValues": [
+          ""
+        ],
+        "foreignKeys": [
+          {
+            "fields": "member_uris",
+            "reference": {
+              "resource": "members",
+              "fields": "uri"
+            },
+            "fields": "item_uri",
+            "reference": {
+              "resource": "books",
+              "fields": "uri"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/data-export-meta/members-datapackage.json
+++ b/data-export-meta/members-datapackage.json
@@ -1,0 +1,149 @@
+{
+    "profile": "tabular-data-package",
+    "title": "Shakespeare and Company Project: Lending Library Members",
+    "homepage": "https://shakespeareandco.princeton.edu/about/data/",
+    "version": "1.0.0",
+    "image": "https://shakespeareandco.princeton.edu/static/img/social.png",
+    "licenses": [{
+        "name": "CC-BY-4.0",
+        "path": "https://creativecommons.org/licenses/by/4.0/",
+        "title": "Creative Commons Attribution 4.0"
+    }],
+    "resources": [
+        {
+            "path": "members.csv",
+            "profile": "tabular-data-resource",
+            "name": "members",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8-sig",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "uri",
+                        "type": "string",
+                        "format": "uri",
+                        "constraints": {
+                            "required": true
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "format": "default",
+                        "constraints": {
+                            "required": true
+                        }
+                    },
+                    {
+                        "name": "sort_name",
+                        "type": "string",
+                        "format": "default",
+                        "constraints": {
+                            "required": true
+                        }
+                    },
+                    {
+                        "name": "title",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "gender",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "is_organization",
+                        "type": "boolean",
+                        "format": "default"
+                    },
+                    {
+                        "name": "has_card",
+                        "type": "boolean",
+                        "format": "default"
+                    },
+                    {
+                        "name": "birth_year",
+                        "type": "year",
+                        "format": "default"
+                    },
+                    {
+                        "name": "death_year",
+                        "type": "year",
+                        "format": "default"
+                    },
+                    {
+                        "name": "membership_years",
+                        "type": "string",
+                        "format": "default",
+                        "rdfType": "https://schema.org/ItemList",
+                        "constraints": {
+                            "pattern": "\\d{4}(;\\d{4})*"
+                        }
+                    },
+                    {
+                        "name": "viaf_url",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "wikipedia_url",
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    {
+                        "name": "nationalities",
+                        "type": "string",
+                        "format": "default",
+                        "rdfType": "https://schema.org/ItemList"
+                    },
+                    {
+                        "name": "addresses",
+                        "type": "string",
+                        "format": "default",
+                        "rdfType": "https://schema.org/ItemList"
+                    },
+                    {
+                        "name": "postal_codes",
+                        "type": "string",
+                        "format": "default",
+                        "rdfType": "https://schema.org/ItemList",
+                        "constraints": {
+                            "pattern": "(\\d{5}|[A-Z \\d]+|)(;(\\d{5}|[A-Z \\d]+|))*"
+                        }
+                    },
+                    {
+                        "name": "arrondissements",
+                        "type": "string",
+                        "format": "default",
+                        "rdfType": "https://schema.org/ItemList",
+                        "constraints": {
+                            "pattern": "(\\d{1,2})?(;(\\d{1,2})?)*"
+                        }
+                    },
+                    {
+                        "name": "coordinates",
+                        "type": "string",
+                        "format": "default",
+                        "rdfType": "https://schema.org/ItemList"
+                    },
+                    {
+                        "name": "notes",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "updated",
+                        "type": "datetime",
+                        "format": "%Y-%m-%dT%H:%M:%S+00:00"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ],
+                "primaryKey": "uri"
+            }
+        }
+    ]
+}

--- a/mep/accounts/management/commands/export_events.py
+++ b/mep/accounts/management/commands/export_events.py
@@ -26,7 +26,7 @@ class Command(BaseExport):
     csv_fields = [
         'event_type',
         'start_date', 'end_date',
-        'member_URIs', 'member_names', 'member_sort_names',
+        'member_uris', 'member_names', 'member_sort_names',
         # subscription specific
         'subscription_price_paid', 'subscription_deposit',
         'subscription_duration', 'subscription_duration_days',
@@ -114,7 +114,7 @@ class Command(BaseExport):
             return
 
         return OrderedDict([
-            ('URIs', [absolutize_url(m.get_absolute_url()) for m in members]),
+            ('uris', [absolutize_url(m.get_absolute_url()) for m in members]),
             ('names', [m.name for m in members]),
             ('sort_names', [m.sort_name for m in members])
         ])

--- a/mep/accounts/management/commands/export_events.py
+++ b/mep/accounts/management/commands/export_events.py
@@ -77,14 +77,14 @@ class Command(BaseExport):
         # subscription-specific data
         if event_type in ['Subscription', 'Supplement', 'Renewal']:
             data['subscription'] = self.subscription_info(obj)
-            currency = obj.subscription.get_currency_display()
+            currency = obj.subscription.currency
 
         # reimbursement data
         elif event_type in 'Reimbursement' and obj.reimbursement.refund:
             data['reimbursement'] = {
                 'refund': '%.2f' % obj.reimbursement.refund
             }
-            currency = obj.reimbursement.get_currency_display()
+            currency = obj.reimbursement.currency
 
         # borrow data
         elif event_type == 'Borrow':
@@ -97,7 +97,7 @@ class Command(BaseExport):
             data['purchase'] = {
                 'price': '%.2f' % obj.purchase.price
             }
-            currency = obj.purchase.get_currency_display()
+            currency = obj.purchase.currency
 
         if currency:
             data['currency'] = currency

--- a/mep/accounts/tests/test_accounts_commands.py
+++ b/mep/accounts/tests/test_accounts_commands.py
@@ -537,7 +537,7 @@ class TestExportEvents(TestCase):
             .first()
         data = self.cmd.get_object_data(event)
         assert data['event_type'] == event.event_label
-        assert data['currency'] == 'French Franc'
+        assert data['currency'] == 'FRF'
         assert 'member' in data
         assert 'subscription in data'
 

--- a/mep/accounts/tests/test_accounts_commands.py
+++ b/mep/accounts/tests/test_accounts_commands.py
@@ -419,7 +419,7 @@ class TestExportEvents(TestCase):
         member_info = self.cmd.member_info(event)
         assert member_info['sort_names'][0] == person.sort_name
         assert member_info['names'][0] == person.name
-        assert member_info['URIs'][0] == \
+        assert member_info['uris'][0] == \
             absolutize_url(person.get_absolute_url())
 
         # event with two members; fixture includes Edel joint account

--- a/mep/accounts/tests/test_accounts_commands.py
+++ b/mep/accounts/tests/test_accounts_commands.py
@@ -539,7 +539,7 @@ class TestExportEvents(TestCase):
         assert data['event_type'] == event.event_label
         assert data['currency'] == 'FRF'
         assert 'member' in data
-        assert 'subscription in data'
+        assert 'subscription' in data
 
     def test_command_line(self):
         # test calling via command line with args


### PR DESCRIPTION
- adds data packages for each of the three current data exports and one combined one
- adds a brief readme to the folder that contains the datapackage files
- minor changes to the event export to move currency into a separate field so monetary amounts can be treated as numeric