### PR TITLE
lstrip punctuation when sorting members

### DIFF
--- a/DEPLOYNOTES.rst
+++ b/DEPLOYNOTES.rst
@@ -3,6 +3,13 @@
 Deploy and Upgrade notes
 ========================
 
+1.3 [IN PROGRESS]
+---
+
+* We updated how members are sorted. We'll need to reindex the Person model::
+
+  python manage.py index -i person
+
 1.2
 ---
 

--- a/mep/people/models.py
+++ b/mep/people/models.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from string import punctuation
 
 from django.apps import apps
 from django.contrib.contenttypes.fields import GenericRelation
@@ -670,7 +671,7 @@ class Person(TrackChangesModel, Notable, DateRange, ModelIndexable):
             # text version of sort name for search and display
             'sort_name_t': self.sort_name,
             # sort version of sort name
-            'sort_name_isort': self.sort_name,
+            'sort_name_isort': self.sort_name.lstrip(punctuation),
             'birth_year_i': self.birth_year,
             'death_year_i': self.death_year,
             'has_card_b': self.has_card(),

--- a/mep/people/tests/test_models.py
+++ b/mep/people/tests/test_models.py
@@ -436,6 +436,15 @@ class TestPerson(TestCase):
         assert uk.name in index_data['nationality']
         assert denmark.name in index_data['nationality']
 
+        # ensure that punctuation is stripped during sort
+        pers = Person.objects.create(
+            name='"Friend of John Smith"', birth_year=1855, death_year=1876,
+            sort_name='"Friend of John Smith"'
+        )
+        acct = Account.objects.create()
+        acct.persons.add(pers)
+        index_data = pers.index_data()
+        assert index_data['sort_name_isort'] == 'Friend of John Smith"'
 
 class TestPersonQuerySet(TestCase):
 


### PR DESCRIPTION
On our deploy, we'll need to clear and rerun the index. Should I preemptively add that to `DEPLOYNOTES`?
Addresses #700 