### PR TITLE
Update subscription duration calculation to account for partial dates

### DIFF
--- a/mep/accounts/tests/test_accounts_models.py
+++ b/mep/accounts/tests/test_accounts_models.py
@@ -730,7 +730,7 @@ class TestSubscription(TestCase):
         expect = 3
         assert subs.duration == expect, \
             "%s should generate duration of '%d', got '%d'" % \
-                (delta, expect, subs.duration)
+            (delta, expect, subs.duration)
 
         # month duration should be actual day count
         # February in a non-leap year; 28 days
@@ -740,7 +740,7 @@ class TestSubscription(TestCase):
         expect = 28
         assert subs.duration == expect, \
             "Month of February should generate duration of '%d', got '%d'" % \
-                (expect, subs.duration)
+            (expect, subs.duration)
         # January in any year; 31 days
         subs = Subscription(start_date=datetime.date(2017, 1, 1),
                             end_date=datetime.date(2017, 2, 1))
@@ -748,7 +748,35 @@ class TestSubscription(TestCase):
         expect = 31
         assert subs.duration == expect, \
             "Month of January should generate duration of '%d', got '%d'" % \
-                (expect, subs.duration)
+            (expect, subs.duration)
+
+    def test_calculate_duration_partial_dates(self):
+        subs = Subscription()
+        # month/day partial dates in (assumed) same year
+        subs.partial_start_date = '--11-05'
+        subs.partial_end_date = '--12-05'
+        subs.calculate_duration()
+        assert subs.duration == 30
+
+        # month/day partial dates that span new year's
+        subs.partial_start_date = '--12-02'
+        subs.partial_end_date = '--01-02'
+        subs.calculate_duration()
+        assert subs.duration == 31
+
+        # mixed precision
+        subs.partial_start_date = '1932-12-02'
+        subs.partial_end_date = '--01-02'
+        subs.calculate_duration()
+        subs.calculate_duration()
+        assert not subs.duration
+
+        # unsupported precision
+        subs.partial_start_date = '1932-12'
+        subs.partial_end_date = '1933-01'
+        subs.calculate_duration()
+        subs.calculate_duration()
+        assert not subs.duration
 
     def test_save(self):
         acct = Account.objects.create()


### PR DESCRIPTION
Updates the subscription calculate_duration method to properly account for partial dates.

I think this will fix the bug reported in #674

I'm hoping to generalize this so I can use it for #718 (exactly same logic, just need to shift the method to the base event class and return the value instead of saving it), but trying to keep PRs atomic so this is just the bug fix.