### PR TITLE
Include borrow duration in event export

### DIFF
--- a/mep/accounts/management/commands/export_events.py
+++ b/mep/accounts/management/commands/export_events.py
@@ -35,7 +35,7 @@ class Command(BaseExport):
         # reimbursement specific
         'reimbursement_refund',
         # borrow specific
-        'borrow_status',
+        'borrow_status', 'borrow_duration_days',
         # purchase specific
         'purchase_price',
         # currency applies to purchase, borrow, and subscription
@@ -91,6 +91,9 @@ class Command(BaseExport):
             data['borrow'] = {
                 'status': obj.borrow.get_item_status_display()
             }
+            borrow_duration = obj.calculate_duration()
+            if borrow_duration:
+                data['borrow']['duration_days'] = borrow_duration
 
         # purchase data
         elif event_type == 'Purchase' and obj.purchase.price:

--- a/mep/accounts/models.py
+++ b/mep/accounts/models.py
@@ -358,8 +358,7 @@ class Event(Notable, PartialDateMixin):
         same or subsequent year.'''
 
         # full precision is either all flags or null/none
-        full_precision = [DatePrecision.year | DatePrecision.month |
-                          DatePrecision.day, None]
+        full_precision = [DatePrecision.all_flags, None]
         month_day = DatePrecision.month | DatePrecision.day
         duration = None
         print(self.start_date, self.end_date)

--- a/mep/accounts/models.py
+++ b/mep/accounts/models.py
@@ -350,6 +350,35 @@ class Event(Notable, PartialDateMixin):
                 return self.nonstandard_notation[match.group(0)]
         return self.event_type
 
+    def calculate_duration(self):
+        '''Calculate and set subscription duration based on start and end
+        date, when both are known. Duration is only calculated when both
+        dates are fully known OR if both dates are month/day only (year
+        unknown), in which case we assume dates are sequential in the
+        same or subsequent year.'''
+
+        # full precision is either all flags or null/none
+        full_precision = [DatePrecision.year | DatePrecision.month |
+                          DatePrecision.day, None]
+        month_day = DatePrecision.month | DatePrecision.day
+        duration = None
+        print(self.start_date, self.end_date)
+
+        if self.start_date and self.end_date and \
+           all(dp in full_precision
+               for dp in (self.start_date_precision, self.end_date_precision))\
+           or (self.start_date_precision == self.end_date_precision == month_day):
+            # calculate duration in days as timedelta from end to start
+            duration = (self.end_date - self.start_date).days
+
+            # if we get a negative duration and year is not known,
+            # assume end date is the following year
+            if (duration < 0) and self.start_date_precision == month_day:
+                self.end_date += relativedelta(years=1)
+                duration = (self.end_date - self.start_date).days
+
+        return duration
+
 
 class SubscriptionType(Named, Notable):
     '''Type of subscription'''
@@ -440,36 +469,10 @@ class Subscription(Event, CurrencyMixin):
         # recalculate duration on save if dates are available,
         # so that duration is always accurate even if dates change
         if self.start_date and self.end_date:
-            self.calculate_duration()
+            self.duration = self.calculate_duration()
         super(Subscription, self).save(*args, **kwargs)
 
-    def calculate_duration(self):
-        '''Calculate and set subscription duration based on start and end
-        date, when both are known. Duration is only calculated when both
-        dates are fully known OR if both dates are month/day only (year
-        unknown), in which case we assume dates are sequential in the
-        same or subsequent year.'''
 
-        # full precision is either all flags or null/none
-        full_precision = [DatePrecision.year | DatePrecision.month |
-                          DatePrecision.day, None]
-        month_day = DatePrecision.month | DatePrecision.day
-
-        if self.start_date and self.end_date and \
-           all(dp in full_precision
-               for dp in (self.start_date_precision, self.end_date_precision))\
-           or (self.start_date_precision == self.end_date_precision == month_day):
-            # calculate duration in days as timedelta from end to start
-            self.duration = (self.end_date - self.start_date).days
-
-            # if we get a negative duration and year is not known,
-            # assume end date is the following year
-            if (self.duration < 0) and self.start_date_precision == month_day:
-                self.end_date += relativedelta(years=1)
-                self.duration = (self.end_date - self.start_date).days
-
-        else:
-            self.duration = None
 
     def validate_unique(self, *args, **kwargs):
         '''Validation check to prevent duplicate events from being

--- a/mep/accounts/tests/test_accounts_commands.py
+++ b/mep/accounts/tests/test_accounts_commands.py
@@ -476,6 +476,15 @@ class TestExportEvents(TestCase):
         event = Event.objects.filter(subscription__isnull=True).first()
         assert not self.cmd.subscription_info(event)
 
+    def test_borrow_info(self):
+        # get a borrow event with both dates
+        event = Event.objects.filter(
+            borrow__isnull=False,
+            start_date__isnull=False, end_date__isnull=False).first()
+        info = self.cmd.get_object_data(event)
+        assert info['borrow']['status'] == event.borrow.get_item_status_display()
+        assert info['borrow']['duration_days'] == event.calculate_duration()
+
     def test_item_data(self):
         # with work uri and notes
         event = Event.objects.filter(work__isnull=False, edition__isnull=True)\

--- a/mep/accounts/tests/test_accounts_models.py
+++ b/mep/accounts/tests/test_accounts_models.py
@@ -726,57 +726,51 @@ class TestSubscription(TestCase):
         # single day
         delta = relativedelta(days=3)
         subs = Subscription(start_date=today, end_date=today + delta)
-        subs.calculate_duration()
+        duration = subs.calculate_duration()
         expect = 3
-        assert subs.duration == expect, \
+        assert duration == expect, \
             "%s should generate duration of '%d', got '%d'" % \
-            (delta, expect, subs.duration)
+            (delta, expect, duration)
 
         # month duration should be actual day count
         # February in a non-leap year; 28 days
         subs = Subscription(start_date=datetime.date(2017, 2, 1),
                             end_date=datetime.date(2017, 3, 1))
-        subs.calculate_duration()
+        duration = subs.calculate_duration()
         expect = 28
-        assert subs.duration == expect, \
+        assert duration == expect, \
             "Month of February should generate duration of '%d', got '%d'" % \
-            (expect, subs.duration)
+            (expect, duration)
         # January in any year; 31 days
         subs = Subscription(start_date=datetime.date(2017, 1, 1),
                             end_date=datetime.date(2017, 2, 1))
-        subs.calculate_duration()
+        duration = subs.calculate_duration()
         expect = 31
-        assert subs.duration == expect, \
+        assert duration == expect, \
             "Month of January should generate duration of '%d', got '%d'" % \
-            (expect, subs.duration)
+            (expect, duration)
 
     def test_calculate_duration_partial_dates(self):
         subs = Subscription()
         # month/day partial dates in (assumed) same year
         subs.partial_start_date = '--11-05'
         subs.partial_end_date = '--12-05'
-        subs.calculate_duration()
-        assert subs.duration == 30
+        assert subs.calculate_duration() == 30
 
         # month/day partial dates that span new year's
         subs.partial_start_date = '--12-02'
         subs.partial_end_date = '--01-02'
-        subs.calculate_duration()
-        assert subs.duration == 31
+        assert subs.calculate_duration() == 31
 
         # mixed precision
         subs.partial_start_date = '1932-12-02'
         subs.partial_end_date = '--01-02'
-        subs.calculate_duration()
-        subs.calculate_duration()
-        assert not subs.duration
+        assert not subs.calculate_duration()
 
         # unsupported precision
         subs.partial_start_date = '1932-12'
         subs.partial_end_date = '1933-01'
-        subs.calculate_duration()
-        subs.calculate_duration()
-        assert not subs.duration
+        assert not subs.calculate_duration()
 
     def test_save(self):
         acct = Account.objects.create()

--- a/mep/accounts/tests/test_accounts_models.py
+++ b/mep/accounts/tests/test_accounts_models.py
@@ -730,7 +730,7 @@ class TestSubscription(TestCase):
         expect = 3
         assert subs.duration == expect, \
             "%s should generate duration of '%d', got '%d'" % \
-                (delta, expect, subs.duration)
+            (delta, expect, subs.duration)
 
         # month duration should be actual day count
         # February in a non-leap year; 28 days
@@ -740,7 +740,7 @@ class TestSubscription(TestCase):
         expect = 28
         assert subs.duration == expect, \
             "Month of February should generate duration of '%d', got '%d'" % \
-                (expect, subs.duration)
+            (expect, subs.duration)
         # January in any year; 31 days
         subs = Subscription(start_date=datetime.date(2017, 1, 1),
                             end_date=datetime.date(2017, 2, 1))
@@ -748,7 +748,35 @@ class TestSubscription(TestCase):
         expect = 31
         assert subs.duration == expect, \
             "Month of January should generate duration of '%d', got '%d'" % \
-                (expect, subs.duration)
+            (expect, subs.duration)
+
+    def test_calculate_duration_partial_dates(self):
+        subs = Subscription()
+        # month/day partial dates in (assumed) same year
+        subs.partial_start_date = '--11-05'
+        subs.partial_end_date = '--12-05'
+        subs.calculate_duration()
+        assert subs.duration == 30
+
+        # month/day partial dates that span new year's
+        subs.partial_start_date = '--12-02'
+        subs.partial_end_date = '--01-02'
+        subs.calculate_duration()
+        assert subs.duration == 31
+
+        # mixed precision
+        subs.partial_start_date = '1932-12-02'
+        subs.partial_end_date = '--01-02'
+        subs.calculate_duration()
+        subs.calculate_duration()
+        assert not subs.duration
+
+        # unsupported precision
+        subs.partial_start_date = '1932-12'
+        subs.partial_end_date = '1933-01'
+        subs.calculate_duration()
+        subs.calculate_duration()
+        assert not subs.duration
 
     def test_save(self):
         acct = Account.objects.create()


### PR DESCRIPTION
this branch is based on work for #674 / PR #719  — that PR should be reviewed & merged first

- move `calculate_duration` method to base event class
- use method to add borrow duration in days to event export

ref #718

