### PR TITLE
Adapt wagtail embed finder from ppa and add support for github pages

### DIFF
--- a/mep/pages/embed_finders.py
+++ b/mep/pages/embed_finders.py
@@ -1,0 +1,78 @@
+'''
+Custom :class:`~wagtail.embeds.finders.base.EmbedFinder` implementations
+for embedding content in wagtail pages.
+'''
+
+from json import JSONDecodeError
+from urllib.parse import urljoin
+
+from bs4 import BeautifulSoup
+import requests
+from wagtail.embeds.finders.base import EmbedFinder
+from wagtail.embeds.exceptions import EmbedException
+
+
+class GlitchHubEmbedFinder(EmbedFinder):
+    '''Custom oembed finder built to embed content from Glitch apps and
+    GitHub pages in wagtail pages.
+
+    To support embedding, the glitch app should include a file named
+    embed.json, available directly under the top level url, with
+    oembed content::
+
+        {
+          "title": "title",
+          "author_name": "author",
+          "provider_name": "Glitch",
+          "type": "rich",
+          "thumbnail_url": "URL to thumbnail image",
+          "width": xx,
+          "height": xx
+        }
+
+    If the request for an embed.json file fails, no content will be embedded.
+
+    Any urls that cannot automatically be made relative by embed code (i.e.
+    data files loaded by javascript code) should use absolute URLs, or they
+    will not resolve when embedded.
+    '''
+
+    def accept(self, url):
+        """
+        Accept a url if it includes `.glitch.me`
+        """
+        # return True if this finder can handle a url; no external requests
+        return any(domain in url for domain in ['.glitch.me', 'github.io'])
+
+    def find_embed(self, url, max_width=None):
+        """
+        Retrieve embed.json and requested url and return content
+        for embedding it on the site.
+        """
+        # NOTE: currently ignores max width
+
+        # implementation assumes that glitch has an embed json file
+        # with appropriate metadata
+        response = requests.get(urljoin(url, 'embed.json'))
+        # if embed info couldn't be loaded, error
+        if response.status_code != requests.codes.ok:
+            raise EmbedException('Failed to load embed.json file')
+        try:
+            embed_info = response.json()
+        except JSONDecodeError:
+            raise EmbedException('Error parsing embed.json file')
+
+        # if embed info request succeeded, then get actual content
+        response = requests.get(url)
+        if response.status_code != requests.codes.ok:
+            raise EmbedException('Failed to load url')
+
+        soup = BeautifulSoup(response.content, 'html.parser')
+        # convert relative links so they are absolute to glitch url
+        for link in soup.find_all(href=True):
+            link['href'] = urljoin(url, link['href'])
+        for source in soup.find_all(src=True):
+            source['src'] = urljoin(url, source['src'])
+
+        embed_info['html'] = soup.prettify()
+        return embed_info

--- a/mep/pages/models.py
+++ b/mep/pages/models.py
@@ -11,9 +11,9 @@ from wagtail.core import blocks
 from wagtail.core.fields import RichTextField, StreamField
 from wagtail.core.models import Page
 from wagtail.documents.blocks import DocumentChooserBlock
+from wagtail.embeds.blocks import EmbedBlock
 from wagtail.images.blocks import ImageChooserBlock
 from wagtail.images.edit_handlers import ImageChooserPanel
-from wagtail.images.models import Image
 from wagtail.snippets.blocks import SnippetChooserBlock
 from wagtail.snippets.models import register_snippet
 
@@ -108,6 +108,7 @@ class BodyContentBlock(blocks.StreamBlock):
         classname='footnotes'
     )
     linkable_section = LinkableSectionBlock()
+    embed = EmbedBlock()
 
 
 class HomePage(Page):

--- a/mep/pages/tests/test_embed_finders.py
+++ b/mep/pages/tests/test_embed_finders.py
@@ -1,0 +1,70 @@
+from json import JSONDecodeError
+from unittest.mock import Mock, patch
+
+import requests
+import pytest
+from wagtail.embeds.exceptions import EmbedException
+
+from mep.pages.embed_finders import GlitchHubEmbedFinder
+
+
+class TestGlitchHubEmbedFinder:
+
+    def test_accept(self):
+        assert GlitchHubEmbedFinder().accept('foobar.glitch.me')
+        assert GlitchHubEmbedFinder().accept('https://princeton-cdh.github.io/app/')
+        assert not GlitchHubEmbedFinder().accept('youtube.com/foo')
+
+    test_html = '''<html>
+    <head>
+        <link rel="stylesheet" type="text/css" href="mystyles.css"/>
+    </head>
+    <body>
+        <script src="myscript.js"></script>
+    </body>
+    </html>
+    '''
+
+    @patch('mep.pages.embed_finders.requests')
+    def test_find_embed(self, mockrequests):
+        # patch in actual request status codes
+        mockrequests.codes = requests.codes
+        glitcher = GlitchHubEmbedFinder()
+
+        # embed response fails
+        mockrequests.get.return_value.status_code = 404
+        with pytest.raises(EmbedException):
+            glitcher.find_embed('http://test.glitch.me')
+        mockrequests.get.assert_called_with('http://test.glitch.me/embed.json')
+
+        # json request succeeeds but main url does not
+        mockrequests.get.side_effect = (Mock(status_code=200),
+                                        Mock(status_code=500))
+        with pytest.raises(EmbedException):
+            glitcher.find_embed('http://test.glitch.me')
+        mockrequests.get.side_effect = None
+
+        # json decode error
+        with pytest.raises(EmbedException):
+            mockrequests.get.return_value.json.side_effect = JSONDecodeError
+            glitcher.find_embed('http://test.glitch.me')
+
+        mockrequests.get.return_value.json.side_effect = None
+
+        mockrequests.get.return_value.status_code = 200
+        mock_embed = {
+            'title': 'test glitch',
+            'author_name': 'me'
+        }
+        mockrequests.get.return_value.json.return_value = mock_embed
+        mockrequests.get.return_value.content = self.test_html
+        embed_info = glitcher.find_embed('http://test.glitch.me')
+        mockrequests.get.assert_called_with('http://test.glitch.me')
+        # embed info from json
+        assert embed_info['title'] == mock_embed['title']
+        assert embed_info['author_name'] == mock_embed['author_name']
+        # html from response content
+        assert embed_info['html'].startswith('<html>')
+        # relative links made absolute
+        assert 'href="http://test.glitch.me/mystyles.css' in embed_info['html']
+        assert 'src="http://test.glitch.me/myscript.js' in embed_info['html']

--- a/mep/settings.py
+++ b/mep/settings.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = [
     'wagtail.images',
     'wagtail.admin',
     'wagtail.core',
+    'wagtail.embeds',
     'wagtail.contrib.redirects',
     'taggit',
     'widget_tweaks',
@@ -182,6 +183,16 @@ OPTIONAL_APPS = (
 )
 
 
+WAGTAILEMBEDS_FINDERS = [
+    {
+        'class': 'wagtail.embeds.finders.oembed'
+    },
+    {
+        'class': 'mep.pages.embed_finders.GlitchHubEmbedFinder'
+    },
+]
+
+
 # pucas configuration that is not expected to change across deploys
 # and does not reference local server configurations or fields
 PUCAS_LDAP = {
@@ -220,19 +231,21 @@ CSP_DEFAULT_SRC = "'none'"
 # allow loading js locally, from google (for analytics), and
 # nytimes github (for svg crowbar)
 CSP_SCRIPT_SRC = ("'self'", 'www.googletagmanager.com',
-                  '*.google-analytics.com', 'nytimes.github.io')
+                  '*.google-analytics.com', 'nytimes.github.io',
+                  'unpkg.com', 'd3js.org', 'princeton-cdh.github.io')
 
 # allow loading fonts locally only
 CSP_FONT_SRC = ("'self'",)
 
 # allow loading css locally & via inline styles
-CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")
+CSP_STYLE_SRC = ("'self'", "'unsafe-inline'", 'unpkg.com')
 
 # allow loading web manifest locally only
 CSP_MANIFEST_SRC = ("'self'",)
 
 # allow XMLHttpRequest or Fetch requests locally (for search), analytics & maps
-CSP_CONNECT_SRC = ("'self'", '*.google-analytics.com', '*.arcgis.com')
+CSP_CONNECT_SRC = ("'self'", '*.google-analytics.com', '*.arcgis.com',
+                   'princeton-cdh.github.io')
 
 # whitelisted image sources - analytics (tracking pixel?), IIIF, maps, etc.
 CSP_IMG_SRC = ("'self'", 'www.googletagmanager.com', '*.google-analytics.com',

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,5 @@ stop_words
 # require django-markdownify < 0.9 for python 3.5 support
 django-markdownify<0.9
 tweepy
+# specify bs4 version to avoid wagtail version conflict
+beautifulsoup4<4.9


### PR DESCRIPTION
- copied custom embed finder & test from ppa code & updated path names
- revised to support github pages urls as well as glitch
- add csp settings to allow loading content from Moacir's map, hosted on princeton-cdh github pages

Actual embed code is unchanged and doesn't need review, but would appreciate quick look over the csp stuff to see if you have any concerns.