### PR TITLE
Upgrade to django-tabular-export v1.2.0 (#844)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,7 @@ dependencies = [
     "python-dateutil",
     "django-apptemplates",
     "py-flags",
-    # latest django-tabular-export does not support Django 4.0+; await release or consider migrating away
-    # "django-tabular-export",
-    "django-tabular-export @ git+https://github.com/rlskoeser/django-tabular-export@django4-compatibility",
+    "django-tabular-export>=1.2.0",
     "django-webpack-loader<=2.0",
     "parasolr>=0.9.2",
     "django-widget-tweaks",


### PR DESCRIPTION
**Associated Issue(s):** #844

### Changes in this PR

- Upgrade to django-tabular-export v1.2.0, which supports Django 4+