### PR TITLE
Use new viapy, jQuery fix for VIAF lookup (#842)

### DIFF
--- a/mep/accounts/static/admin/borrow-admin-list.js
+++ b/mep/accounts/static/admin/borrow-admin-list.js
@@ -1,10 +1,13 @@
+// alias jquery to $ for convenience
+const $ = jQuery;
+
 $(function(){
     $radios = $('.grp-row input[type="radio"]')
     // bold all of the checked options on page load
     $radios.filter(':checked').parent().css('font-weight', 'bold')
     $radios.change(function(event){
         // unbold all sibling options on change
-        $(event.target).parents('ul').find('label').css('font-weight', 'normal')
+        $(event.target).parents('td').find('label').css('font-weight', 'normal')
         // rebold only the selected option
         $(event.target).parent().css('font-weight', 'bold')
     })

--- a/mep/books/oclc.py
+++ b/mep/books/oclc.py
@@ -8,7 +8,7 @@ import time
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from neuxml.xmlmap import core, fields
+from neuxml import xmlmap
 from lxml.etree import XMLSyntaxError
 import pymarc
 import rdflib
@@ -69,15 +69,15 @@ class WorldCatClientBase:
             logger.exception(err)
 
 
-class SRWResponse(core.XmlObject):
+class SRWResponse(xmlmap.XmlObject):
     """Object to parse SRW formatted responses."""
 
     ROOT_NAMESPACES = {"srw": "http://www.loc.gov/zing/srw/"}
 
     #: number of records found for the query
-    num_records = fields.IntegerField("srw:numberOfRecords")
+    num_records = xmlmap.IntegerField("srw:numberOfRecords")
     #: returned records as :class:`~neuxml.xmlmap.XmlObject`
-    records = fields.NodeField("srw:records", core.XmlObject)
+    records = xmlmap.NodeField("srw:records", xmlmap.XmlObject)
 
     @property
     def marc_records(self):
@@ -300,7 +300,7 @@ class SRUSearch(WorldCatClientBase):
         if response:
             # parse and return as SRW Response
             try:
-                return core.load_xmlobject_from_string(response.content, SRWResponse)
+                return xmlmap.load_xmlobject_from_string(response.content, SRWResponse)
             except XMLSyntaxError as err:
                 # occasionally getting parsing error exceptions; log it
                 # include first part of response content in case it helps

--- a/mep/books/tests/test_oclc.py
+++ b/mep/books/tests/test_oclc.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
-from neuxml.xmlmap import core
+from neuxml import xmlmap
 import pymarc
 import pytest
 import rdflib
@@ -98,7 +98,7 @@ SRW_RESPONSE_FIXTURE = os.path.join(FIXTURE_DIR, "oclc_srw_response.xml")
 def get_srwresponse_xml_fixture():
     # test utility method to initialize and return SRWResponse
     # XmlObject from fixture
-    return core.load_xmlobject_from_file(SRW_RESPONSE_FIXTURE, SRWResponse)
+    return xmlmap.load_xmlobject_from_file(SRW_RESPONSE_FIXTURE, SRWResponse)
 
 
 @override_settings(OCLC_WSKEY="my-secret-key")

--- a/mep/people/static/admin/viaf-lookup.js
+++ b/mep/people/static/admin/viaf-lookup.js
@@ -1,3 +1,6 @@
+// alias jquery to $ for convenience
+const $ = jQuery;
+
 $(document).on('select2:select', function(evt) {
     var data = evt.params.data;
     var target = evt.target;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ dependencies = [
     # github until neuxml 1.0.0 released
     # "neuxml>=1.0.0",
     "neuxml @ git+https://github.com/Princeton-CDH/neuxml",
-    "viapy>=0.3",
+    # github until next viapy release
+    # "viapy>=0.3",
+    "viapy @ git+https://github.com/Princeton-CDH/viapy@develop",
     "wagtail>=6.4,<6.5",
     "django-autocomplete-light>=3.9",
     "python-dateutil",

--- a/sitemedia/admin/js/person-editlink.js
+++ b/sitemedia/admin/js/person-editlink.js
@@ -2,6 +2,9 @@
 Customize person edit input (dal select2) on account page to generate
 a link to the person edit page based on the selection.
 */
+// alias jquery to $ for convenience
+const $ = jQuery;
+
 $(document).ready(function() {
     // store reference to the form input with the person ids
     var person_select = $('#id_persons');

--- a/sitemedia/admin/js/prepopulate.js
+++ b/sitemedia/admin/js/prepopulate.js
@@ -7,59 +7,55 @@ special class names to control behavior:
  - "prepopulate-nopace": clear prepopulated value if source value
    contains spaces. (only valid with prepopulate-noslug)
 */
+$.fn.prepopulate = function(dependencies, maxLength, allowUnicode) {
+    /*
+        Depends on urlify.js
+        Populates a selected field with the values of the dependent fields,
+        URLifies and shortens the string.
+        dependencies - array of dependent fields ids
+        maxLength - maximum length of the URLify'd string
+        allowUnicode - Unicode support of the URLify'd string
+    */
+    return this.each(function() {
+        const prepopulatedField = $(this);
 
-(function($) {
-    'use strict';
-    $.fn.prepopulate = function(dependencies, maxLength, allowUnicode) {
-        /*
-            Depends on urlify.js
-            Populates a selected field with the values of the dependent fields,
-            URLifies and shortens the string.
-            dependencies - array of dependent fields ids
-            maxLength - maximum length of the URLify'd string
-            allowUnicode - Unicode support of the URLify'd string
-        */
-        return this.each(function() {
-            var prepopulatedField = $(this);
+        const populate = function() {
+            console.log('populate');
+            // Bail if the field's value has been changed by the user
+            if (prepopulatedField.data('_changed')) {
+                return;
+            }
 
-            var populate = function() {
-                console.log('populate');
-                // Bail if the field's value has been changed by the user
-                if (prepopulatedField.data('_changed')) {
-                    return;
+            const values = [];
+            $.each(dependencies, function(i, field) {
+                field = $(field);
+                if (field.val().length > 0) {
+                    values.push(field.val());
                 }
-
-                var values = [];
-                $.each(dependencies, function(i, field) {
-                    field = $(field);
-                    if (field.val().length > 0) {
-                        values.push(field.val());
-                    }
-                });
-
-                var value;
-                if (prepopulatedField.attr('class').indexOf('prepopulate-noslug') !== -1) {
-                    // just use the values without slugifying
-                    value = values.join(' ');
-                    if (prepopulatedField.attr('class').indexOf('prepopulate-nospace') !== -1
-                        && value.indexOf(' ') !== -1) {
-                        value = '';
-                    }
-                } else {
-                    // default django prepopulate behavior
-                    value = URLify(values.join(' '), maxLength, allowUnicode);
-                }
-                prepopulatedField.val(value);
-            };
-
-            prepopulatedField.data('_changed', false);
-            prepopulatedField.change(function() {
-                prepopulatedField.data('_changed', true);
             });
 
-            if (!prepopulatedField.val()) {
-                $(dependencies.join(',')).keyup(populate).change(populate).focus(populate);
+            let value;
+            if (prepopulatedField.attr('class').indexOf('prepopulate-noslug') !== -1) {
+                // just use the values without slugifying
+                value = values.join(' ');
+                if (prepopulatedField.attr('class').indexOf('prepopulate-nospace') !== -1
+                    && value.indexOf(' ') !== -1) {
+                    value = '';
+                }
+            } else {
+                // default django prepopulate behavior
+                value = URLify(values.join(' '), maxLength, allowUnicode);
             }
+            prepopulatedField.val(value);
+        };
+
+        prepopulatedField.data('_changed', false);
+        prepopulatedField.on('change', function() {
+            prepopulatedField.data('_changed', true);
         });
-    };
-})(grp.jQuery);
+
+        if (!prepopulatedField.val()) {
+            $(dependencies.join(',')).on('keyup change focus', populate);
+        }
+    });
+};


### PR DESCRIPTION
**Associated Issue(s):** #842, #843

### Changes in this PR

- Update to latest `viapy` from github
- Alias `jQuery` to `$` in all needed places
- Fix a broken jQuery function assignment in `prepopulate`
- Fix unbolding bug in `borrow-admin-list` due to DOM change
- Revert the `neuxml.xmlmap` references to the (new) old style

### Notes

- I noticed that because `slug` depends on `sort_name` it also gets blanked out if you include a space in a person's name due to `sort_name` having `prepopulate-nospace`. I'm assuming that's intentional, to ensure the slug and sort name are in sync, but just wanted to flag in case it wasn't.
- I also made a few other small changes to the prepopulate script to bring it up to speed with [the current django version](https://github.com/django/django/blob/f7d97dd11819be8996798a7197c5695a317334a0/django/contrib/admin/static/admin/js/prepopulate.js) (really just replacing deprecated jQuery calls and `var`)—recommend using "Hide whitespace" to review
