### PR TITLE
Bump Wagtail to 7.0.1 (#857)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pucas>=0.8",
     "neuxml>=1.0.0",
     "viapy>=0.4",
-    "wagtail>=6.4,<6.5",
+    "wagtail>=7.0,<7.1",
     "django-autocomplete-light>=3.9",
     "python-dateutil",
     "django-apptemplates",


### PR DESCRIPTION
**Associated Issue(s):** #857

### Changes in this PR

- Bump wagtail from 6 to 7.0.1

### Notes

- As with PPA, I tested [validation on saving drafts](https://docs.wagtail.org/en/stable/releases/7.0.html#configuring-deferred-validation-of-required-fields) and [JS presence](https://docs.wagtail.org/en/stable/releases/7.0.html#removal-of-insert-editor-js-hook-output-in-some-non-editor-views) locally.